### PR TITLE
Update variables.tf

### DIFF
--- a/infra/azure/variables.tf
+++ b/infra/azure/variables.tf
@@ -69,7 +69,7 @@ variable "azure_k8s_region" {
 }
 
 variable "azure_aks_k8s_version" {
-  default = "1.23.5"
+  default = "1.23.12"
 }
 
 variable "tsb_mp" {


### PR DESCRIPTION
Azure removed v1.23.5
verified 1.23.12 works

verified with `az aks get-versions --location westus2`
```bash
      "default": true,
      "isPreview": null,
      "orchestratorType": "Kubernetes",
      "orchestratorVersion": "1.23.12",
```