### PR TITLE
Renamed status to state, added tf ```.terraform``` cache folder clean up and providers version lock`.terraform.lock.hcl`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,8 @@ destroy:  ## Destroy the environment
 		cd "../../.."; \
 		'
 	@$(MAKE) destroy_gcp destroy_aws destroy_azure
-	@$(MAKE) destroy_status
+	@$(MAKE) destroy_tfstate
+	@$(MAKE) destroy_tfcache
 
 destroy_%:
 	@/bin/sh -c '\
@@ -203,7 +204,12 @@ destroy_%:
 		done; \
 		'
 
-.PHONY: destroy_status
-destroy_status:
+.PHONY: destroy_tfstate
+destroy_tfstate:
 	find . -name terraform.tfstate.d -exec rm -rf {} \;
 	find . -name terraform.tfstate -delete
+
+.PHONY: destroy_tfcache
+destroy_tfcache:
+	find . -name .terraform -exec rm -rf {} \;
+	find . -name .terraform.lock.hcl -delete


### PR DESCRIPTION
Renamed status to state, added tf ```.terraform``` cache folder clean up and providers version lock`.terraform.lock.hcl`.

as play is run, lock is generated for dependencies, so if the same folder is used to destroy/re-build the older cache will be utilized.

as per https://developer.hashicorp.com/terraform/cli/init