### PR TITLE
Fix private DNS in GCP after merge and other fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,10 +206,10 @@ destroy_%:
 
 .PHONY: destroy_tfstate
 destroy_tfstate:
-	find . -name terraform.tfstate.d -exec rm -rf {} \;
+	find . -name terraform.tfstate.d -exec rm -rf {} +
 	find . -name terraform.tfstate -delete
 
 .PHONY: destroy_tfcache
 destroy_tfcache:
-	find . -name .terraform -exec rm -rf {} \;
+	find . -name .terraform -exec rm -rf {} +
 	find . -name .terraform.lock.hcl -delete

--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ destroy:  ## Destroy the environment
 		fqdn=`jq -r '.tsb_fqdn' terraform.tfvars.json`; \
 		address=`jq -r "if .ingress_ip.value != \"\" then .ingress_ip.value else .ingress_hostname.value end" outputs/terraform_outputs/terraform-tsb-mp.json`; \
 		cd "tsb/fqdn/$$cloud"; \
-		terraform destroy ${terraform_apply_args} -var=address=$$address -var=fqdn=$$fqdn; \
+		terraform destroy ${terraform_apply_args} -var-file="../../../terraform.tfvars.json" -var=address=$$address -var=fqdn=$$fqdn; \
 		rm -rf terraform.tfstate.d/; \
 		rm -rf terraform.tfstate; \
 		cd "../../.."; \

--- a/addons/argocd/main.tf
+++ b/addons/argocd/main.tf
@@ -1,39 +1,15 @@
-data "terraform_remote_state" "aws" {
-  count   = length(var.aws_k8s_regions)
+data "terraform_remote_state" "infra" {
   backend = "local"
   config = {
-    path = "../../infra/aws/terraform.tfstate.d/aws-${count.index}-${var.aws_k8s_regions[count.index]}/terraform.tfstate"
-  }
-}
-
-data "terraform_remote_state" "azure" {
-  count   = length(var.azure_k8s_regions)
-  backend = "local"
-  config = {
-    path = "../../infra/azure/terraform.tfstate.d/azure-${count.index}-${var.azure_k8s_regions[count.index]}/terraform.tfstate"
-  }
-}
-
-data "terraform_remote_state" "gcp" {
-  count   = length(var.gcp_k8s_regions)
-  backend = "local"
-  config = {
-    path = "../../infra/gcp/terraform.tfstate.d/gcp-${count.index}-${var.gcp_k8s_regions[count.index]}/terraform.tfstate"
-  }
-}
-
-data "terraform_remote_state" "tsb_mp" {
-  backend = "local"
-  config = {
-    path = "../../tsb/mp/terraform.tfstate"
+    path = "../../infra/${var.cloud}/terraform.tfstate.d/${var.cloud}-${var.cluster_id}-${local.k8s_regions[var.cluster_id]}/terraform.tfstate"
   }
 }
 
 module "argocd" {
   source                     = "../../modules/addons/argocd"
-  cluster_name               = local.infra[var.cloud][var.cluster_id]["outputs"].cluster_name
-  k8s_host                   = local.infra[var.cloud][var.cluster_id]["outputs"].host
-  k8s_cluster_ca_certificate = local.infra[var.cloud][var.cluster_id]["outputs"].cluster_ca_certificate
-  k8s_client_token           = local.infra[var.cloud][var.cluster_id]["outputs"].token
+  cluster_name               = terraform_remote_state.infra.outputs.cluster_name
+  k8s_host                   = terraform_remote_state.infra.outputs.host
+  k8s_cluster_ca_certificate = terraform_remote_state.infra.outputs.cluster_ca_certificate
+  k8s_client_token           = terraform_remote_state.infra.outputs.token
   password                   = var.tsb_password
 }

--- a/addons/argocd/variables.tf
+++ b/addons/argocd/variables.tf
@@ -12,11 +12,9 @@ variable "owner" {
 }
 
 locals {
-  infra = {
-    aws   = data.terraform_remote_state.aws
-    azure = data.terraform_remote_state.azure
-    gcp   = data.terraform_remote_state.gcp
-  }
+  k8s_regions = var.cloud == "aws" ? var.aws_k8s_regions : (
+    var.cloud == "azure" ? var.azure_k8s_regions : var.gcp_k8s_regions
+  )
 }
 
 variable "name_prefix" {

--- a/apps/apps.tf
+++ b/apps/apps.tf
@@ -1,7 +1,0 @@
-module "app_bookinfo" {
-  source                     = "./modules/apps/bookinfo"
-  cluster_name               = local.cloud[var.cloud][var.cluster_id].cluster_name
-  k8s_host                   = local.cloud[var.cloud][var.cluster_id].host
-  k8s_cluster_ca_certificate = local.cloud[var.cloud][var.cluster_id].cluster_ca_certificate
-  k8s_client_token           = local.cloud[var.cloud][var.cluster_id].token
-}

--- a/modules/apps/eshop/main.tf
+++ b/modules/apps/eshop/main.tf
@@ -41,6 +41,16 @@ data "kubectl_path_documents" "trafficgen" {
   }
 }
 
+resource "kubernetes_namespace" "eshop" {
+  for_each = toset(["eshop", "checkout", "payments", "trafficgen"])
+  metadata {
+    name = each.value
+    labels = {
+      "istio-injection" = "enabled"
+    }
+  }
+}
+
 resource "kubectl_manifest" "services" {
   for_each = merge(
     data.kubectl_path_documents.services["eshop"].manifests,
@@ -50,4 +60,5 @@ resource "kubectl_manifest" "services" {
     data.kubectl_path_documents.trafficgen.manifests
   )
   yaml_body = each.value
+  depends_on = [kubernetes_namespace.eshop]
 }

--- a/modules/apps/eshop/manifests/apps/services.yaml
+++ b/modules/apps/eshop/manifests/apps/services.yaml
@@ -1,10 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: ${namespace}
-  labels:
-    istio-injection: enabled
----
 %{ for svc in split(",", services) }
 apiVersion: v1
 kind: Service

--- a/modules/apps/eshop/manifests/apps/trafficgen.yaml
+++ b/modules/apps/eshop/manifests/apps/trafficgen.yaml
@@ -1,10 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: trafficgen
-  labels:
-    istio-injection: enabled
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/modules/tsb/cp/manifests/tctl/tctl-controlplane.sh.tmpl
+++ b/modules/tsb/cp/manifests/tctl/tctl-controlplane.sh.tmpl
@@ -7,13 +7,13 @@
 /usr/bin/env tctl x gitops grant ${cluster_name}
 
 # Allow managing platform Roles with the cluster service account
-tctl get ab admin/rbac -o json >/tmp/rbac.json
+/usr/bin/env tctl get ab admin/rbac -o json >rbac.json
 if [ $? -eq 0 ]; then
    echo "Adding ${cluster_name} to existing RBAC policy..."
-   jq --arg cluster organizations/tetrate/serviceaccounts/cluster-${cluster_name} '. | select(.spec.allow[].role=="rbac/admin").spec.allow[].subjects +=[{"serviceAccount":$cluster}]' /tmp/rbac.json | tctl apply -f -
+   jq --arg cluster organizations/tetrate/serviceaccounts/cluster-${cluster_name} '. | select(.spec.allow[].role=="rbac/admin").spec.allow[].subjects +=[{"serviceAccount":$cluster}]' rbac.json | tctl apply -f -
 else
   echo "Creating RBAC policy and adding ${cluster_name}..."
-  tctl apply -f - <<EOF
+  /usr/bin/env tctl apply -f - <<EOF
 apiVersion: rbac.tsb.tetrate.io/v2
 kind: AccessBindings
 metadata:

--- a/modules/tsb/cp/manifests/tctl/tctl-controlplane.sh.tmpl
+++ b/modules/tsb/cp/manifests/tctl/tctl-controlplane.sh.tmpl
@@ -7,7 +7,13 @@
 /usr/bin/env tctl x gitops grant ${cluster_name}
 
 # Allow managing platform Roles with the cluster service account
-/usr/bin/env tctl apply -f - <<EOF
+tctl get ab admin/rbac -o json >/tmp/rbac.json
+if [ $? -eq 0 ]; then
+   echo "Adding ${cluster_name} to existing RBAC policy..."
+   jq --arg cluster organizations/tetrate/serviceaccounts/cluster-${cluster_name} '. | select(.spec.allow[].role=="rbac/admin").spec.allow[].subjects +=[{"serviceAccount":$cluster}]' /tmp/rbac.json | tctl apply -f -
+else
+  echo "Creating RBAC policy and adding ${cluster_name}..."
+  tctl apply -f - <<EOF
 apiVersion: rbac.tsb.tetrate.io/v2
 kind: AccessBindings
 metadata:
@@ -18,3 +24,4 @@ spec:
     subjects:
     - serviceAccount: organizations/tetrate/serviceaccounts/cluster-${cluster_name}
 EOF
+fi

--- a/modules/tsb/cp/manifests/tctl/tctl-controlplane.sh.tmpl
+++ b/modules/tsb/cp/manifests/tctl/tctl-controlplane.sh.tmpl
@@ -16,5 +16,5 @@ spec:
   allow:
   - role: rbac/admin
     subjects:
-    - service_account: organizations/tetrate/serviceaccounts/cluster-${cluster_name}
+    - serviceAccount: organizations/tetrate/serviceaccounts/cluster-${cluster_name}
 EOF

--- a/tsb/cp/variables.tf
+++ b/tsb/cp/variables.tf
@@ -12,8 +12,6 @@ variable "owner" {
 }
 
 locals {
-  infra = data.terraform_remote_state.infra
-
   k8s_regions = var.cloud == "aws" ? var.aws_k8s_regions : (
     var.cloud == "azure" ? var.azure_k8s_regions : var.gcp_k8s_regions
   )

--- a/tsb/fqdn/gcp/main.tf
+++ b/tsb/fqdn/gcp/main.tf
@@ -1,7 +1,7 @@
 data "terraform_remote_state" "infra" {
   backend = "local"
   config = {
-    path = "../../../infra/${var.tsb_mp["cloud"]}/terraform.tfstate.d/${var.tsb_mp["cloud"]}-${var.tsb_mp["cluster_id"]}-${local.k8s_regions[tonumber(var.tsb_mp["cluster_id"])]}/terraform.tfstate"
+    path = "../../../infra/gcp/terraform.tfstate.d/gcp-${var.tsb_mp["cluster_id"]}-${var.gcp_k8s_regions[tonumber(var.tsb_mp["cluster_id"])]}/terraform.tfstate"
   }
 }
 
@@ -10,6 +10,6 @@ module "register_fqdn" {
   dns_zone      = var.dns_zone
   fqdn          = var.fqdn
   address       = var.address
-  project_id    = local.infra["outputs"].project_id
-  vpc_id        = reverse(split("/", local.infra["outputs"].vpc_id))[0]
+  project_id    = data.terraform_remote_state.infra.outputs.project_id
+  vpc_id        = reverse(split("/", data.terraform_remote_state.infra.outputs.vpc_id))[0]
 }

--- a/tsb/fqdn/gcp/main.tf
+++ b/tsb/fqdn/gcp/main.tf
@@ -11,5 +11,5 @@ module "register_fqdn" {
   fqdn          = var.fqdn
   address       = var.address
   project_id    = local.infra["outputs"].project_id
-  vpc_id        = local.infra["outputs"].vpc_id
+  vpc_id        = reverse(split("/", local.infra["outputs"].vpc_id))[0]
 }

--- a/tsb/fqdn/gcp/variables.tf
+++ b/tsb/fqdn/gcp/variables.tf
@@ -12,7 +12,3 @@ variable "tsb_mp" {
 variable "gcp_k8s_regions" {
   default = []
 }
-locals {
-  infra = data.terraform_remote_state.infra
-  k8s_regions = var.gcp_k8s_regions
-}


### PR DESCRIPTION
This PR fixes the private DNS setup in GCP that was missing [this from the original PR](https://github.com/smarunich/tetrate-service-bridge-sandbox/pull/129/files#diff-b9e7412e7c9ac84c1d30c5422670ce63f1ee37b8a913dcb0914c9bf90b9aa4f5R13).

It also removes some unneeded access to additional cloud providers and makes the eshop deploy a bit more resilient.