### PR TITLE
Improve skopeo sync and automatically get internal gcr token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # Local .terraform directories
 **/.terraform/*
 tests/*
-*.sh
 *.tfvars.json
 
 # .tfstate files

--- a/DEVELOPMENT_BUILD.md
+++ b/DEVELOPMENT_BUILD.md
@@ -2,9 +2,8 @@
 
 If you want to provision the latest master build you have to:
 
-1. Provide ```tetrate_internal_cr``` variable as ```gcr.io/...```.
-2. Provide ```tetrate_internal_cr_token``` variable using ```gcloud auth print-access-token```
-3. Specify ```tsb_version``` that includes ```dev``` suffix, for example ```"tsb_version": "1.6.0-dev"```
+1. Specify ```tsb_version``` that includes ```dev``` suffix, for example ```"tsb_version": "1.6.0-dev"```
+2. Have the ```gcloud``` CLI installed on your machine. It will be used to get a token to access the internal releases registry.
 
 A complete reference example:
 
@@ -28,8 +27,6 @@ terraform.tfvars.json
     ],
     "gcp_k8s_regions": [
         "us-west1"
-    ],
-    "tetrate_internal_cr": "gcr.io/..",
-    "tetrate_internal_cr_token": "..."
+    ]
 }
 ```

--- a/infra/aws/main.tf
+++ b/infra/aws/main.tf
@@ -20,8 +20,6 @@ module "aws_jumpbox" {
   vpc_subnet                = module.aws_base[0].vpc_subnets[0]
   cidr                      = module.aws_base[0].cidr
   tsb_version               = var.tsb_version
-  tetrate_internal_cr       = var.tetrate_internal_cr
-  tetrate_internal_cr_token = var.tetrate_internal_cr_token
   jumpbox_username          = var.jumpbox_username
   tsb_image_sync_username   = var.tsb_image_sync_username
   tsb_image_sync_apikey     = var.tsb_image_sync_apikey

--- a/infra/aws/variables.tf
+++ b/infra/aws/variables.tf
@@ -88,10 +88,3 @@ variable "output_path" {
 variable "cert-manager_enabled" {
   default = true
 }
-
-variable "tetrate_internal_cr" {
-  default = ""
-}
-variable "tetrate_internal_cr_token" {
-  default = ""
-}

--- a/infra/azure/main.tf
+++ b/infra/azure/main.tf
@@ -21,8 +21,6 @@ module "azure_jumpbox" {
   cidr                      = module.azure_base[0].cidr
   vnet_subnet               = module.azure_base[0].vnet_subnets[0]
   tsb_version               = var.tsb_version
-  tetrate_internal_cr       = var.tetrate_internal_cr
-  tetrate_internal_cr_token = var.tetrate_internal_cr_token
   jumpbox_username          = var.jumpbox_username
   tsb_image_sync_username   = var.tsb_image_sync_username
   tsb_image_sync_apikey     = var.tsb_image_sync_apikey

--- a/infra/azure/variables.tf
+++ b/infra/azure/variables.tf
@@ -83,10 +83,3 @@ variable "output_path" {
 variable "cert-manager_enabled" {
   default = true
 }
-
-variable "tetrate_internal_cr" {
-  default = ""
-}
-variable "tetrate_internal_cr_token" {
-  default = ""
-}

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -42,8 +42,6 @@ module "gcp_jumpbox" {
   vpc_id                    = module.gcp_base[0].vpc_id
   vpc_subnet                = module.gcp_base[0].vpc_subnets[0]
   tsb_version               = var.tsb_version
-  tetrate_internal_cr       = var.tetrate_internal_cr
-  tetrate_internal_cr_token = var.tetrate_internal_cr_token
   jumpbox_username          = var.jumpbox_username
   machine_type              = var.jumpbox_machine_type
   tsb_image_sync_username   = var.tsb_image_sync_username

--- a/infra/gcp/variables.tf
+++ b/infra/gcp/variables.tf
@@ -100,10 +100,3 @@ variable "output_path" {
 variable "cert-manager_enabled" {
   default = true
 }
-
-variable "tetrate_internal_cr" {
-  default = ""
-}
-variable "tetrate_internal_cr_token" {
-  default = ""
-}

--- a/modules/aws/jumpbox/jumpbox.userdata
+++ b/modules/aws/jumpbox/jumpbox.userdata
@@ -26,26 +26,19 @@ write_files:
       curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
       install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
       ${docker_login}
-      export PROJECT_CR="${registry}"
-      # to initialize CR metadata and use skopeo for TSB images sync below
-      docker pull busybox
-      docker tag busybox $PROJECT_CR/busybox
-      docker push $PROJECT_CR/busybox
-      export TSB_VERSION="${tsb_version}"
-      if [[ "$TSB_VERSION" =~ .*"-dev" ]]; then
+      if [[ ! -z "${tetrate_internal_cr}" ]]; then
         curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
         helm repo add tetrate-tsb-helm 'https://charts.dl.tetrate.io/public/helm/charts/'
         helm repo update
         curl -Lo "/usr/local/bin/tctl" "https://binaries.dl.tetrate.io/public/raw/versions/linux-amd64-next/tctl"
         chmod +x "/usr/local/bin/tctl"
-        helm pull tetrate-tsb-helm/managementplane --version $TSB_VERSION --devel
-        tar zxvf managementplane-$TSB_VERSION.tgz
-        export TETRATE_INTERNAL_CR="${tetrate_internal_cr}"
-        export TETRATE_INTERNAL_CR_TOKEN="${tetrate_internal_cr_token}"
-        sed -i "s#containers.dl.tetrate.io#$TETRATE_INTERNAL_CR#g" managementplane/images.txt
-        for IMAGE in $(cat managementplane/images.txt)
+        helm pull tetrate-tsb-helm/managementplane --version ${tsb_version} --devel
+        tar zxvf managementplane-${tsb_version}.tgz
+        for IMAGE in $(cut -d/ -f2- managementplane/images.txt)
         do 
-          skopeo sync --src-registry-token $TETRATE_INTERNAL_CR_TOKEN --dest-authfile /root/.docker/config.json --src docker --dest docker $IMAGE $PROJECT_CR &
+          skopeo copy --src-registry-token "${tetrate_internal_cr_token}" --dest-authfile /root/.docker/config.json \
+            docker://${tetrate_internal_cr}/$IMAGE \
+            docker://${registry}/$IMAGE &
         done
       else
         curl -Lo "/usr/local/bin/tctl" "https://binaries.dl.tetrate.io/public/raw/versions/linux-amd64-${tsb_version}/tctl"
@@ -53,7 +46,7 @@ write_files:
         tctl install image-sync \
           --username "${tsb_image_sync_username}" \
           --apikey "${tsb_image_sync_apikey}" \
-          --registry $PROJECT_CR \
+          --registry ${registry} \
           --accept-eula \
           --parallel
       fi

--- a/modules/aws/jumpbox/main.tf
+++ b/modules/aws/jumpbox/main.tf
@@ -223,6 +223,11 @@ data "aws_ami" "ubuntu" {
 
 data "aws_availability_zones" "available" {}
 
+module "internal_registry" {
+  source      = "../../internal_registry"
+  tsb_version = var.tsb_version
+}
+
 resource "aws_instance" "jumpbox" {
   ami               = data.aws_ami.ubuntu.id
   availability_zone = data.aws_availability_zones.available.names[0]
@@ -248,8 +253,8 @@ resource "aws_instance" "jumpbox" {
     docker_login              = "aws ecr get-login-password --region ${data.aws_availability_zones.available.id} | docker login --username AWS --password-stdin ${var.registry}"
     registry                  = var.registry
     pubkey                    = tls_private_key.generated.public_key_openssh
-    tetrate_internal_cr       = var.tetrate_internal_cr
-    tetrate_internal_cr_token = var.tetrate_internal_cr_token
+    tetrate_internal_cr       = module.internal_registry.internal_cr
+    tetrate_internal_cr_token = module.internal_registry.internal_cr_token
   }))
   iam_instance_profile = aws_iam_instance_profile.jumpbox_iam_profile.name
 

--- a/modules/aws/jumpbox/variables.tf
+++ b/modules/aws/jumpbox/variables.tf
@@ -37,10 +37,3 @@ variable "tsb_version" {
 
 variable "output_path" {
 }
-
-variable "tetrate_internal_cr" {
-  default = ""
-}
-variable "tetrate_internal_cr_token" {
-  default = ""
-}

--- a/modules/azure/jumpbox/jumpbox.userdata
+++ b/modules/azure/jumpbox/jumpbox.userdata
@@ -26,26 +26,19 @@ write_files:
       curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
       install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
       ${docker_login}
-      export PROJECT_CR="${registry}"
-      # to initialize CR metadata and use skopeo for TSB images sync below
-      docker pull busybox
-      docker tag busybox $PROJECT_CR/busybox
-      docker push $PROJECT_CR/busybox
-      export TSB_VERSION="${tsb_version}"
-      if [[ "$TSB_VERSION" =~ .*"-dev" ]]; then
+      if [[ ! -z "${tetrate_internal_cr}" ]]; then
         curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
         helm repo add tetrate-tsb-helm 'https://charts.dl.tetrate.io/public/helm/charts/'
         helm repo update
         curl -Lo "/usr/local/bin/tctl" "https://binaries.dl.tetrate.io/public/raw/versions/linux-amd64-next/tctl"
         chmod +x "/usr/local/bin/tctl"
-        helm pull tetrate-tsb-helm/managementplane --version $TSB_VERSION --devel
-        tar zxvf managementplane-$TSB_VERSION.tgz
-        export TETRATE_INTERNAL_CR="${tetrate_internal_cr}"
-        export TETRATE_INTERNAL_CR_TOKEN="${tetrate_internal_cr_token}"
-        sed -i "s#containers.dl.tetrate.io#$TETRATE_INTERNAL_CR#g" managementplane/images.txt
-        for IMAGE in $(cat managementplane/images.txt)
+        helm pull tetrate-tsb-helm/managementplane --version ${tsb_version} --devel
+        tar zxvf managementplane-${tsb_version}.tgz
+        for IMAGE in $(cut -d/ -f2- managementplane/images.txt)
         do 
-          skopeo sync --src-registry-token $TETRATE_INTERNAL_CR_TOKEN --dest-authfile /root/.docker/config.json --src docker --dest docker $IMAGE $PROJECT_CR &
+          skopeo copy --src-registry-token "${tetrate_internal_cr_token}" --dest-authfile /root/.docker/config.json \
+            docker://${tetrate_internal_cr}/$IMAGE \
+            docker://${registry}/$IMAGE &
         done
       else
         curl -Lo "/usr/local/bin/tctl" "https://binaries.dl.tetrate.io/public/raw/versions/linux-amd64-${tsb_version}/tctl"
@@ -53,7 +46,7 @@ write_files:
         tctl install image-sync \
           --username "${tsb_image_sync_username}" \
           --apikey "${tsb_image_sync_apikey}" \
-          --registry $PROJECT_CR \
+          --registry ${registry} \
           --accept-eula \
           --parallel
       fi

--- a/modules/azure/jumpbox/main.tf
+++ b/modules/azure/jumpbox/main.tf
@@ -99,6 +99,11 @@ resource "tls_private_key" "generated" {
   rsa_bits  = 4096
 }
 
+module "internal_registry" {
+  source      = "../../internal_registry"
+  tsb_version = var.tsb_version
+}
+
 resource "azurerm_linux_virtual_machine" "jumpbox" {
   name                  = "${var.name_prefix}-jumpbox-vm"
   location              = var.location
@@ -116,8 +121,8 @@ resource "azurerm_linux_virtual_machine" "jumpbox" {
     registry_admin            = var.registry_username
     registry_password         = var.registry_password
     pubkey                    = tls_private_key.generated.public_key_openssh
-    tetrate_internal_cr       = var.tetrate_internal_cr
-    tetrate_internal_cr_token = var.tetrate_internal_cr_token
+    tetrate_internal_cr       = module.internal_registry.internal_cr
+    tetrate_internal_cr_token = module.internal_registry.internal_cr_token
   }))
 
 

--- a/modules/azure/jumpbox/variables.tf
+++ b/modules/azure/jumpbox/variables.tf
@@ -46,10 +46,3 @@ variable "tsb_version" {
 
 variable "output_path" {
 }
-
-variable "tetrate_internal_cr" {
-  default = ""
-}
-variable "tetrate_internal_cr_token" {
-  default = ""
-}

--- a/modules/gcp/jumpbox/jumpbox.userdata
+++ b/modules/gcp/jumpbox/jumpbox.userdata
@@ -26,26 +26,19 @@ write_files:
       curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
       install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
       ${docker_login}
-      export PROJECT_CR="${registry}"
-      # to initialize CR metadata and use skopeo for TSB images sync below
-      docker pull busybox
-      docker tag busybox $PROJECT_CR/busybox
-      docker push $PROJECT_CR/busybox
-      export TSB_VERSION="${tsb_version}"
-      if [[ "$TSB_VERSION" =~ .*"-dev" ]]; then
+      if [[ ! -z "${tetrate_internal_cr}" ]]; then
         curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
         helm repo add tetrate-tsb-helm 'https://charts.dl.tetrate.io/public/helm/charts/'
         helm repo update
         curl -Lo "/usr/local/bin/tctl" "https://binaries.dl.tetrate.io/public/raw/versions/linux-amd64-next/tctl"
         chmod +x "/usr/local/bin/tctl"
-        helm pull tetrate-tsb-helm/managementplane --version $TSB_VERSION --devel
-        tar zxvf managementplane-$TSB_VERSION.tgz
-        export TETRATE_INTERNAL_CR="${tetrate_internal_cr}"
-        export TETRATE_INTERNAL_CR_TOKEN="${tetrate_internal_cr_token}"
-        sed -i "s#containers.dl.tetrate.io#$TETRATE_INTERNAL_CR#g" managementplane/images.txt
-        for IMAGE in $(cat managementplane/images.txt)
+        helm pull tetrate-tsb-helm/managementplane --version ${tsb_version} --devel
+        tar zxvf managementplane-${tsb_version}.tgz
+        for IMAGE in $(cut -d/ -f2- managementplane/images.txt)
         do 
-          skopeo sync --src-registry-token $TETRATE_INTERNAL_CR_TOKEN --dest-authfile /root/.docker/config.json --src docker --dest docker $IMAGE $PROJECT_CR &
+          skopeo copy --src-registry-token "${tetrate_internal_cr_token}" --dest-authfile /root/.docker/config.json \
+            docker://${tetrate_internal_cr}/$IMAGE \
+            docker://${registry}/$IMAGE &
         done
       else
         curl -Lo "/usr/local/bin/tctl" "https://binaries.dl.tetrate.io/public/raw/versions/linux-amd64-${tsb_version}/tctl"
@@ -53,7 +46,7 @@ write_files:
         tctl install image-sync \
           --username "${tsb_image_sync_username}" \
           --apikey "${tsb_image_sync_apikey}" \
-          --registry $PROJECT_CR \
+          --registry ${registry} \
           --accept-eula \
           --parallel
       fi

--- a/modules/gcp/jumpbox/main.tf
+++ b/modules/gcp/jumpbox/main.tf
@@ -23,6 +23,10 @@ data "google_compute_default_service_account" "default" {
   ]
 }
 
+module "internal_registry" {
+  source      = "../../internal_registry"
+  tsb_version = var.tsb_version
+}
 
 resource "google_compute_instance" "jumpbox" {
   project      = var.project_id
@@ -58,8 +62,8 @@ resource "google_compute_instance" "jumpbox" {
       docker_login              = "gcloud auth configure-docker -q"
       registry                  = var.registry
       pubkey                    = tls_private_key.generated.public_key_openssh
-      tetrate_internal_cr       = var.tetrate_internal_cr
-      tetrate_internal_cr_token = var.tetrate_internal_cr_token
+      tetrate_internal_cr       = module.internal_registry.internal_cr
+      tetrate_internal_cr_token = module.internal_registry.internal_cr_token
     })
   }
 

--- a/modules/gcp/jumpbox/variables.tf
+++ b/modules/gcp/jumpbox/variables.tf
@@ -38,10 +38,3 @@ variable "machine_type" {
 
 variable "output_path" {
 }
-
-variable "tetrate_internal_cr" {
-  default = ""
-}
-variable "tetrate_internal_cr_token" {
-  default = ""
-}

--- a/modules/internal_registry/internal-cr-token.sh
+++ b/modules/internal_registry/internal-cr-token.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+VERSION=$(jq -r '.tsb_version')
+
+if [[ "${VERSION}" =~ .*"-dev" ]]; then
+    REGISTRY="gcr.io/tetrate-internal-containers"
+    TOKEN=$(gcloud auth print-access-token)
+fi
+
+echo "{\"token\": \"${TOKEN}\",\"registry\":\"${REGISTRY}\"}"

--- a/modules/internal_registry/main.tf
+++ b/modules/internal_registry/main.tf
@@ -1,0 +1,7 @@
+
+data "external" "gcr_token" {
+  program = ["bash", "${path.module}/internal-cr-token.sh"]
+  query = {
+    "tsb_version" = var.tsb_version
+  }
+}

--- a/modules/internal_registry/outputs.tf
+++ b/modules/internal_registry/outputs.tf
@@ -1,0 +1,8 @@
+output "internal_cr" {
+  value = data.external.gcr_token.result.registry
+}
+
+output "internal_cr_token" {
+  value = data.external.gcr_token.result.token
+  sensitive = true
+}

--- a/modules/internal_registry/variables.tf
+++ b/modules/internal_registry/variables.tf
@@ -1,0 +1,2 @@
+variable "tsb_version" {
+}


### PR DESCRIPTION
Fixes https://github.com/smarunich/tetrate-service-bridge-sandbox/issues/144

This changes the jumpbox sync to use `skopeo copy` and do not require to pull the random busybox image.

It also removes the need to manually pass the internal registry and token when using development versions. The internal registry is very unlikely to change, so this change encapsulates it in the `internal_registry` module instead.

The only drawback of this change is that the internal token may be generated on every run, but IMO this is a good enough tradeoff: it would only redeploy the jumpbox and at the time of re-running the `dev` version may already be pointing at a new commit (plus, how many times do we re-apply existing environments? At the time of doing that it is likely that the old token is already expired, so I think it is a good enough tradeoff for simplicity).