### PR TITLE
addressing argocd variables run bug

### DIFF
--- a/addons/argocd/main.tf
+++ b/addons/argocd/main.tf
@@ -7,9 +7,9 @@ data "terraform_remote_state" "infra" {
 
 module "argocd" {
   source                     = "../../modules/addons/argocd"
-  cluster_name               = terraform_remote_state.infra.outputs.cluster_name
-  k8s_host                   = terraform_remote_state.infra.outputs.host
-  k8s_cluster_ca_certificate = terraform_remote_state.infra.outputs.cluster_ca_certificate
-  k8s_client_token           = terraform_remote_state.infra.outputs.token
+  cluster_name               = data.terraform_remote_state.infra.outputs.cluster_name
+  k8s_host                   = data.terraform_remote_state.infra.outputs.host
+  k8s_cluster_ca_certificate = data.terraform_remote_state.infra.outputs.cluster_ca_certificate
+  k8s_client_token           = data.terraform_remote_state.infra.outputs.token
   password                   = var.tsb_password
 }


### PR DESCRIPTION
i.e. missing `data` prefix