### PR TITLE
eshop ingress with rate limiting and optional WAF

### DIFF
--- a/apps/eshop/README.md
+++ b/apps/eshop/README.md
@@ -11,7 +11,8 @@ It consists of two applications:
 The `payments` service is configured to introduce a 200ms latency, and the `checkout`
 service is configured to fail 20% of the requests.  
 The `eshop` ingress gateway is also
-configured to rate-limit to a max of 3 requests per second per unique client address.   
+configured to rate-limit to a max of 3 requests per second per unique client address, and with
+WAF settings that load the Core Rule Set and have request body inspection enabled. 
 Hierarchical policies are set to limit access to the `payments` application from the `checkout`
 security group.
 
@@ -46,3 +47,33 @@ You can configure the following environment variables as well to customize the i
 | tenant_owner | nacx | Username of the owner of the eShop tenant |
 | eshop_owner | zack | Username of the owner of the eShop workspace |
 | payments_owner | wusheng | Username of the owner of the payments workspace |
+
+## Example requests to showcase WAF
+
+Get the address of the eShop ingress gateway as follows:
+
+```bash
+export ESHOP_GW=$(kubectl -n eshop get svc tsb-gateway-eshop -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+```
+
+Example malicious requests rejected by the WAF:
+
+```bash
+# XSS in the query parameters
+curl -i -H "Host: eshop.tetrate.io" -H "X-B3-Sampled: 1" \
+    "http://${ESHOP_GW}/proxy/orders?arg=<script>alert(0)</script>"
+
+# SQL Injection in the request payload (leverages request body inspection)
+curl -i -X POST -H "Host: eshop.tetrate.io" \
+    --data "1%27%20ORDER%20BY%203--%2B" -H "X-B3-Sampled: 1" \
+    http://${ESHOP_GW}/proxy/orders
+
+# Vulnerability scanner detection
+curl -i -H "Host: eshop.tetrate.io" -H "X-B3-Sampled: 1" \
+    --user-agent "Grabber/0.1 (X11; U; Linux i686; en-US; rv:1.7)" \
+    http://${ESHOP_GW}/proxy/orders
+
+# Custom rule that rejects an invalid ID
+curl -i -H "Host: eshop.tetrate.io" -H "X-B3-Sampled: 1" \
+    "http://${ESHOP_GW}/proxy/orders?id=0"
+```

--- a/apps/eshop/main.tf
+++ b/apps/eshop/main.tf
@@ -18,4 +18,5 @@ module "eshop" {
   tenant_owner               = var.tenant_owner
   eshop_owner                = var.eshop_owner
   payments_owner             = var.payments_owner
+  enable_waf                 = var.enable_waf
 }

--- a/apps/eshop/variables.tf
+++ b/apps/eshop/variables.tf
@@ -35,3 +35,7 @@ variable "eshop_owner" {
 variable "payments_owner" {
   default = "wusheng"
 }
+
+variable "enable_waf" {
+  default = false
+}

--- a/modules/apps/eshop/manifests/tsb/ingress.yaml
+++ b/modules/apps/eshop/manifests/tsb/ingress.yaml
@@ -19,6 +19,26 @@ spec:
       - route:
           host: payments/payments.payments.svc.cluster.local
           port: 80
+    rateLimiting:
+      settings:
+        rules:
+          - dimensions:
+              - remoteAddress:
+                  value: '*'
+            limit:
+              requestsPerUnit: 3
+              unit: SECOND
+%{ if enable_waf }
+  waf:
+    rules:
+      - Include @recommended-conf         # Recommended basic setup
+      - SecRuleEngine On                  # Override DetectionOnly mode in @recommended-conf
+      - SecResponseBodyAccess Off         # Override to not process response bodies
+      - Include crs-setup.conf.example    # Initialize the Core Rule Set
+      - Include @owasp_crs/*.conf         # Load the Core Rule Set
+      # Custom rule to deny requests with query parameter 'id=0'
+      - SecRule ARGS:id "@eq 0" "id:1, phase:1,deny, status:403,msg:'Invalid id',log,auditlog"
+%{ endif }
   workloadSelector:
     labels:
       app: tsb-gateway-payments

--- a/modules/apps/eshop/tsb.tf
+++ b/modules/apps/eshop/tsb.tf
@@ -35,6 +35,7 @@ data "kubectl_path_documents" "ingress_config" {
   vars    = {
     eshop_host     = var.eshop_host
     payments_host  = var.payments_host
+    enable_waf     = var.enable_waf
   }
 }
 

--- a/modules/apps/eshop/variables.tf
+++ b/modules/apps/eshop/variables.tf
@@ -30,3 +30,6 @@ variable "eshop_owner" {
 
 variable "payments_owner" {
 }
+
+variable "enable_waf" {
+}


### PR DESCRIPTION
Opening as draft because in the latest master some of the WAF features referenced here are not yet available. This depends on a couple PRs being merged to capture the last WAF WASM image with the filesystem aliases.