### PR TITLE
adding support for cr-pull-secret for wasm

### DIFF
--- a/infra/aws/outputs.tf
+++ b/infra/aws/outputs.tf
@@ -2,6 +2,15 @@ output "registry" {
   value = module.aws_base[0].registry
 }
 
+output "registry_username" {
+  value = module.aws_base[0].registry_username
+}
+
+output "registry_password" {
+  value = module.aws_base[0].registry_password
+  sensitive = true
+}
+
 output "public_ip" {
   value = module.aws_jumpbox[0].public_ip
 }

--- a/infra/azure/outputs.tf
+++ b/infra/azure/outputs.tf
@@ -2,6 +2,15 @@ output "registry" {
   value = module.azure_base[0].registry
 }
 
+output "registry_username" {
+  value = module.azure_base[0].registry_username
+}
+
+output "registry_password" {
+  value = module.azure_base[0].registry_password
+  sensitive = true
+}
+
 output "public_ip" {
   value = module.azure_jumpbox[0].public_ip
 }

--- a/infra/gcp/outputs.tf
+++ b/infra/gcp/outputs.tf
@@ -2,6 +2,15 @@ output "registry" {
   value = module.gcp_base[0].registry
 }
 
+output "registry_username" {
+  value = module.gcp_base[0].registry_username
+}
+
+output "registry_password" {
+  value = module.gcp_base[0].registry_password
+  sensitive = true
+}
+
 output "public_ip" {
   value = module.gcp_jumpbox[0].public_ip
 }

--- a/modules/aws/base/main.tf
+++ b/modules/aws/base/main.tf
@@ -85,3 +85,5 @@ resource "aws_ecr_repository" "tsb" {
   }
 }
 
+data "aws_ecr_authorization_token" "token" {
+}

--- a/modules/aws/base/outputs.tf
+++ b/modules/aws/base/outputs.tf
@@ -14,6 +14,14 @@ output "registry_id" {
   value = aws_ecr_repository.tsb.registry_id
 }
 
+output "registry_username" {
+  value = data.aws_ecr_authorization_token.token.user_name
+}
+
+output "registry_password" {
+  value = data.aws_ecr_authorization_token.token.password
+}
+
 output "cidr" {
   value = var.cidr
 }

--- a/modules/azure/base/outputs.tf
+++ b/modules/azure/base/outputs.tf
@@ -18,16 +18,15 @@ output "registry" {
   value = azurerm_container_registry.acr.login_server
 }
 
+output "registry_id" {
+  value = azurerm_container_registry.acr.id
+}
 output "registry_username" {
   value = azurerm_container_registry.acr.admin_username
 }
 
 output "registry_password" {
   value = azurerm_container_registry.acr.admin_password
-}
-
-output "registry_id" {
-  value = azurerm_container_registry.acr.id
 }
 
 output "cidr" {

--- a/modules/gcp/base/main.tf
+++ b/modules/gcp/base/main.tf
@@ -91,3 +91,22 @@ resource "google_compute_firewall" "tsb" {
   }
 
 }
+
+resource "google_service_account" "gcr_pull" {
+  project = var.project_id
+  account_id = "${var.name_prefix}-gcr-pull"
+}
+resource "google_project_iam_member" "storage_viewer" {
+  project = var.project_id
+  role = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.gcr_pull.email}"
+}
+resource "google_project_iam_member" "artifact_reader" {
+  project = var.project_id
+  role = "roles/artifactregistry.reader"
+  member = "serviceAccount:${google_service_account.gcr_pull.email}"
+}
+
+resource "google_service_account_key" "gcr_pull_key" {
+  service_account_id = google_service_account.gcr_pull.name
+}

--- a/modules/gcp/base/outputs.tf
+++ b/modules/gcp/base/outputs.tf
@@ -13,6 +13,13 @@ output "registry" {
   value = "gcr.io/${var.project_id}"
 }
 
+output "registry_username" {
+  value = "_json_key"
+}
+output "registry_password" {
+  value = base64decode(google_service_account_key.gcr_pull_key.private_key)
+}
+
 output "cidr" {
   value = var.cidr
 }

--- a/modules/tsb/cp/main.tf
+++ b/modules/tsb/cp/main.tf
@@ -132,12 +132,17 @@ resource "kubernetes_secret_v1" "cr_pull_secret" {
   }
 
   data = {
-    "docker-server"    = var.registry
-    "docker-username"  = var.registry_username
-    "docker-password"  = var.registry_password
+    ".dockerconfigjson" = jsonencode({
+      auths = {
+        "${var.registry}" = {
+          "username" = var.registry_username
+          "password" = var.registry_password
+        }
+      }
+    })
   }
 
-  type       = "kubernetes.io/generic"
+  type       = "kubernetes.io/dockerconfigjson"
   depends_on = [helm_release.controlplane]
 }
 

--- a/modules/tsb/cp/main.tf
+++ b/modules/tsb/cp/main.tf
@@ -121,6 +121,26 @@ resource "kubernetes_secret_v1" "cacerts" {
   type       = "kubernetes.io/generic"
   depends_on = [helm_release.controlplane]
 }
+
+resource "kubernetes_secret_v1" "cr_pull_secret" {
+  metadata {
+    name      = "cr-pull-secret"
+    namespace = "istio-system"
+    annotations = {
+      clustername = var.cluster_name
+    }
+  }
+
+  data = {
+    "docker-server"    = var.registry
+    "docker-username"  = var.registry_username
+    "docker-password"  = var.registry_password
+  }
+
+  type       = "kubernetes.io/generic"
+  depends_on = [helm_release.controlplane]
+}
+
 resource "helm_release" "dataplane" {
   name                = "dataplane"
   repository          = var.tsb_helm_repository

--- a/modules/tsb/cp/variables.tf
+++ b/modules/tsb/cp/variables.tf
@@ -72,7 +72,10 @@ variable "tsb_image_sync_apikey" {
 
 variable "registry" {
 }
-
+variable "registry_username" {
+}
+variable "registry_password" {
+}
 variable "es_host" {
 }
 

--- a/tsb/cp/main.tf
+++ b/tsb/cp/main.tf
@@ -53,6 +53,8 @@ module "tsb_cp" {
   jumpbox_username                = var.jumpbox_username
   jumpbox_pkey                    = data.terraform_remote_state.infra.outputs.pkey
   registry                        = data.terraform_remote_state.infra.outputs.registry
+  registry_username               = data.terraform_remote_state.infra.outputs.registry_username
+  registry_password               = data.terraform_remote_state.infra.outputs.registry_password
   cluster_name                    = data.terraform_remote_state.infra.outputs.cluster_name
   k8s_host                        = data.terraform_remote_state.infra.outputs.host
   k8s_cluster_ca_certificate      = data.terraform_remote_state.infra.outputs.cluster_ca_certificate


### PR DESCRIPTION
adds `cr-pull-secret` under istio-system namespace for the further use by `WASM` extensions, watch out for ECR as the `cr-pull-secret` has to be refreshed every 12 hrs, where it is a static construct for Azure and Google.