### PR TITLE
adding depends on cluster for gke_auth module

### DIFF
--- a/modules/gcp/k8s/main.tf
+++ b/modules/gcp/k8s/main.tf
@@ -61,6 +61,9 @@ module "gke_auth" {
   cluster_name         = google_container_cluster.tsb.name
   location             = var.region
   use_private_endpoint = false
+  depends_on = [
+    google_container_cluster.tsb
+  ]
 }
 
 resource "local_file" "kubeconfig" {


### PR DESCRIPTION
the latest updates to terraform stopped respecting implicit deps