### PR TITLE
removing the bindings until @nacx fix

### DIFF
--- a/modules/apps/eshop/manifests/tsb/permissions.yaml
+++ b/modules/apps/eshop/manifests/tsb/permissions.yaml
@@ -44,28 +44,28 @@ spec:
     - apiGroup: api.tsb.tetrate.io/v2
       kinds:
       - Tenant
----
-apiVersion: rbac.tsb.tetrate.io/v2
-kind: AccessBindings
-metadata:
-  name: tetrate-org
-  namespace: eshop-config
-  annotations:
-    tsb.tetrate.io/fqn: organizations/tetrate
-spec:
-  allow:
-  - role: rbac/registryreader
-    subjects:
-    - team: organizations/tetrate/teams/everyone
-  - role: rbac/user-reader
-    subjects:
-    - team: organizations/tetrate/teams/everyone
-  - role: rbac/cluster-reader
-    subjects:
-    - team: organizations/tetrate/teams/everyone
-  - role: rbac/admin
-    subjects:
-    - serviceAccount: teamsync-job
+# ---
+# apiVersion: rbac.tsb.tetrate.io/v2
+# kind: AccessBindings
+# metadata:
+#   name: tetrate-org
+#   namespace: eshop-config
+#   annotations:
+#     tsb.tetrate.io/fqn: organizations/tetrate
+# spec:
+#   allow:
+#   - role: rbac/registryreader
+#     subjects:
+#     - team: organizations/tetrate/teams/everyone
+#   - role: rbac/user-reader
+#     subjects:
+#     - team: organizations/tetrate/teams/everyone
+#   - role: rbac/cluster-reader
+#     subjects:
+#     - team: organizations/tetrate/teams/everyone
+#   - role: rbac/admin
+#     subjects:
+#     - serviceAccount: teamsync-job
 ---
 apiVersion: rbac.tsb.tetrate.io/v2
 kind: AccessBindings


### PR DESCRIPTION
the existing eshop gitops config does affect `cluster` service accounts org bindings, as we cannot patch the access bindings, i.e. access binding has to be a singular object