### PR TITLE
Allow to opt-out of preemptible nodes in GKE

### DIFF
--- a/DEVELOPMENT_BUILD.md
+++ b/DEVELOPMENT_BUILD.md
@@ -1,4 +1,4 @@
-# DEVELOPMENT_BUILD.md
+# Provisioning development versions
 
 If you want to provision the latest master build you have to:
 

--- a/README.md
+++ b/README.md
@@ -142,3 +142,14 @@ make destroy
   if you own a domain that you can point to your GCP project, you can use any `fqdn` as long as it does _not_
   have the shared DNS suffix (gcp.cx.tetrate.info). In this case a public DNS zone will be created in the project
   for the configured DNS domain.
+
+### Repository structure
+
+| Directory | Description |
+| --------- | ----------- |
+| [addons](addons) | Terraform modules to deploy optional add-ons such as ArgoCD or the TSB monitoring stack. |
+| [gitops](gitops) | Example application configurations to be used with the ArgoCD addon. |
+| [infra](infra) | Infrastructure deployment modules. Provisioning of networking, jumpboxes and k8s clusters. |
+| [modules](modules) | Generic and reusable terraform modules. These should not contain any specific configuration. |
+| [outputs](outputs) | Terraform output values for the provisioned modules. |
+| [tsb](tsb) | TSB Terraform modules to deploy the TSB MP and TSB CPs. |

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -52,16 +52,17 @@ module "gcp_jumpbox" {
 }
 
 module "gcp_k8s" {
-  source       = "../../modules/gcp/k8s"
-  count        = var.gcp_k8s_region == null ? 0 : 1
-  owner        = replace(var.tsb_image_sync_username, "/\\W+/", "-")
-  name_prefix  = "${var.name_prefix}-${var.cluster_id}"
-  cluster_name = var.cluster_name == null ? "gke-${var.gcp_k8s_region}-${var.name_prefix}" : var.cluster_name
-  project_id   = var.gcp_project_id == null ? google_project.tsb[0].project_id : var.gcp_project_id
-  vpc_id       = module.gcp_base[0].vpc_id
-  vpc_subnet   = module.gcp_base[0].vpc_subnets[0]
-  region       = var.gcp_k8s_region
-  k8s_version  = var.gcp_gke_k8s_version
-  output_path  = var.output_path
-  depends_on   = [module.gcp_jumpbox[0]]
+  source             = "../../modules/gcp/k8s"
+  count              = var.gcp_k8s_region == null ? 0 : 1
+  owner              = replace(var.tsb_image_sync_username, "/\\W+/", "-")
+  name_prefix        = "${var.name_prefix}-${var.cluster_id}"
+  cluster_name       = var.cluster_name == null ? "gke-${var.gcp_k8s_region}-${var.name_prefix}" : var.cluster_name
+  project_id         = var.gcp_project_id == null ? google_project.tsb[0].project_id : var.gcp_project_id
+  vpc_id             = module.gcp_base[0].vpc_id
+  vpc_subnet         = module.gcp_base[0].vpc_subnets[0]
+  region             = var.gcp_k8s_region
+  preemptible_nodes  = var.preemptible_nodes
+  k8s_version        = var.gcp_gke_k8s_version
+  output_path        = var.output_path
+  depends_on         = [module.gcp_jumpbox[0]]
 }

--- a/infra/gcp/variables.tf
+++ b/infra/gcp/variables.tf
@@ -100,3 +100,7 @@ variable "output_path" {
 variable "cert-manager_enabled" {
   default = true
 }
+
+variable "preemptible_nodes" {
+  default = true
+}

--- a/infra/gcp/variables.tf
+++ b/infra/gcp/variables.tf
@@ -102,5 +102,5 @@ variable "cert-manager_enabled" {
 }
 
 variable "preemptible_nodes" {
-  default = true
+  default = false
 }

--- a/modules/gcp/k8s/main.tf
+++ b/modules/gcp/k8s/main.tf
@@ -32,7 +32,7 @@ resource "google_container_cluster" "tsb" {
   ]
 }
 
-resource "google_container_node_pool" "primary_preemptible_nodes" {
+resource "google_container_node_pool" "primary_nodes" {
   name       = "${var.cluster_name}-pool"
   project    = var.project_id
   location   = var.region
@@ -40,7 +40,7 @@ resource "google_container_node_pool" "primary_preemptible_nodes" {
   node_count = 1
 
   node_config {
-    preemptible  = true
+    preemptible  = var.preemptible_nodes
     machine_type = "e2-standard-4"
 
     # Google recommends custom service accounts that have cloud-platform scope and permissions granted via IAM Roles.

--- a/modules/gcp/k8s/variables.tf
+++ b/modules/gcp/k8s/variables.tf
@@ -23,7 +23,7 @@ variable "region" {
 }
 
 variable "preemptible_nodes" {
-  default = true
+  default = false
 }
 
 variable "k8s_version" {

--- a/modules/gcp/k8s/variables.tf
+++ b/modules/gcp/k8s/variables.tf
@@ -22,6 +22,10 @@ variable "vpc_subnet" {
 variable "region" {
 }
 
+variable "preemptible_nodes" {
+  default = true
+}
+
 variable "k8s_version" {
 }
 


### PR DESCRIPTION
When building scenarios to do customer demos, having preemptible nodes adds too much uncertainty to the availability of the cluster. We still default to preemptible, but with this change we allow configuring standard VMs to create more stable environments.

cc @gonzaloserrano