### PR TITLE
Allow configuring ArgoCD and Grafana service types

### DIFF
--- a/addons/argocd/main.tf
+++ b/addons/argocd/main.tf
@@ -11,6 +11,7 @@ module "argocd" {
   k8s_host                   = data.terraform_remote_state.infra.outputs.host
   k8s_cluster_ca_certificate = data.terraform_remote_state.infra.outputs.cluster_ca_certificate
   k8s_client_token           = data.terraform_remote_state.infra.outputs.token
+  service_type               = var.argocd_service_type
   password                   = var.tsb_password
 
   applications = {for a in fileset("${path.module}/applications", "*.yaml") : a => file("${path.module}/applications/${a}")}

--- a/addons/argocd/variables.tf
+++ b/addons/argocd/variables.tf
@@ -121,3 +121,7 @@ variable "output_path" {
 variable "cert-manager_enabled" {
   default = true
 }
+
+variable "argocd_service_type" {
+  default = "LoadBalancer"
+}

--- a/addons/monitoring/main.tf
+++ b/addons/monitoring/main.tf
@@ -21,6 +21,7 @@ module "grafana" {
   k8s_cluster_ca_certificate = data.terraform_remote_state.infra.outputs.cluster_ca_certificate
   k8s_client_token           = data.terraform_remote_state.infra.outputs.token
   namespace                  = "tsb-monitoring"
+  service_type               = var.grafana_service_type
   password                   = var.tsb_password
   
   dashboards = {for d in fileset("${path.module}/dashboards", "*.json") : d => file("${path.module}/dashboards/${d}")}

--- a/addons/monitoring/variables.tf
+++ b/addons/monitoring/variables.tf
@@ -121,3 +121,7 @@ variable "output_path" {
 variable "cert-manager_enabled" {
   default = true
 }
+
+variable "grafana_service_type" {
+  default = "ClusterIP"
+}

--- a/gitops/eshop/tsb-config.yaml
+++ b/gitops/eshop/tsb-config.yaml
@@ -134,7 +134,6 @@ items:
           - Include @owasp_crs/*.conf         # Load the Core Rule Set
           # Custom rule to deny requests with query parameter 'id=0'
           - SecRule ARGS:id "@eq 0" "id:1,phase:1,deny,status:403,msg:'Invalid id',log,auditlog"
-          - SecRule REQUEST_HEADERS:user-agent "@contains curl" "id:2,pass,log,logdata:'someone used curl to access'"
       workloadSelector:
         labels:
           app: tsb-gateway-eshop

--- a/modules/addons/argocd/main.tf
+++ b/modules/addons/argocd/main.tf
@@ -37,7 +37,7 @@ resource "helm_release" "argocd" {
 
   set {
     name  = "server.service.type"
-    value = "LoadBalancer"
+    value = var.service_type
   }
 }
 

--- a/modules/addons/argocd/variables.tf
+++ b/modules/addons/argocd/variables.tf
@@ -16,3 +16,7 @@ variable "password" {
 
 variable "applications" {
 }
+
+variable "service_type" {
+  default = "ClusterIP"
+}

--- a/modules/addons/grafana/main.tf
+++ b/modules/addons/grafana/main.tf
@@ -25,12 +25,10 @@ resource "helm_release" "grafana" {
   namespace        = var.namespace
   timeout          = 900
 
-  values = [file("${path.module}/manifests/grafana-values.yaml")]
-
-  set {
-    name  = "adminPassword"
-    value = coalesce(var.password, random_password.grafana.result)
-  }
+  values = [templatefile("${path.module}/manifests/grafana-values.yaml.tmpl", {
+    admin_password = coalesce(var.password, random_password.grafana.result)
+    service_type   = var.service_type
+  })]
 }
 
 data "kubectl_path_documents" "tsb_dashboards" {

--- a/modules/addons/grafana/manifests/grafana-values.yaml.tmpl
+++ b/modules/addons/grafana/manifests/grafana-values.yaml.tmpl
@@ -1,5 +1,7 @@
+adminPassword: "${admin_password}"
 service:
   port: 3000
+  type: ${service_type}
 datasources:
   datasources.yaml:
     apiVersion: 1

--- a/modules/addons/grafana/variables.tf
+++ b/modules/addons/grafana/variables.tf
@@ -19,3 +19,7 @@ variable "dashboards" {
 variable "password" {
   default = ""
 }
+
+variable "service_type" {
+  default = "ClusterIP"
+}


### PR DESCRIPTION
Just adding some minor configurable variables, keeping the current defaults, to configure grafana and argocd service types, which ar probably the ones commonly accessed in demos.