### PR TITLE
module azure_vnet update

### DIFF
--- a/modules/azure/base/main.tf
+++ b/modules/azure/base/main.tf
@@ -24,6 +24,7 @@ module "vnet" {
   vnet_name           = "${var.name_prefix}_vnet"
   source              = "Azure/vnet/azurerm"
   vnet_location       = var.location
+  use_for_each        = false
   resource_group_name = azurerm_resource_group.tsb.name
   address_space       = [var.cidr]
   subnet_prefixes     = local.subnet_prefixes


### PR DESCRIPTION
In v4.0.0, we would make var.use_for_each a required variable so the users must set the value explicitly. For whom are maintaining the existing infrastructure that was created with count should use false, for those who are creating a new stack, we encourage them to use true.

V4.0.0 is a major version upgrade. Extreme caution must be taken during the upgrade to avoid resource replacement and downtime by accident.

https://registry.terraform.io/modules/Azure/vnet/azurerm/latest