### PR TITLE
switch to `kubenet` to workaround number of pods per node limitation

### DIFF
--- a/modules/azure/k8s/main.tf
+++ b/modules/azure/k8s/main.tf
@@ -10,7 +10,7 @@ resource "azurerm_kubernetes_cluster" "k8s" {
   private_cluster_enabled = false
 
   network_profile {
-    network_plugin = "azure"
+    network_plugin = "kubenet"
   }
 
   default_node_pool {


### PR DESCRIPTION
https://learn.microsoft.com/en-us/azure/aks/configure-azure-cni

The maximum number of pods per node in an AKS cluster is 250. The default maximum number of pods per node varies between kubenet and Azure CNI networking, and the method of cluster deployment.

Deployment method	Kubenet default	Azure CNI default	Configurable at deployment Azure CLI	110	30	Yes (up to 250)
Resource Manager template	110	30	Yes (up to 250)
Portal	110	110 (configurable in the Node Pools tab)	Yes (up to 250)