### PR TITLE
Set `package_update: true` to address cloud-init install package fail…

### DIFF
--- a/modules/aws/jumpbox/jumpbox.userdata
+++ b/modules/aws/jumpbox/jumpbox.userdata
@@ -1,4 +1,8 @@
 #cloud-config
+repo_update: true
+repo_upgrade: all
+package_update: true
+package_upgrade: true
 packages:
   - language-pack-en
   - docker.io

--- a/modules/azure/jumpbox/jumpbox.userdata
+++ b/modules/azure/jumpbox/jumpbox.userdata
@@ -1,4 +1,8 @@
 #cloud-config
+repo_update: true
+repo_upgrade: all
+package_update: true
+package_upgrade: true
 packages:
   - language-pack-en
   - docker.io

--- a/modules/gcp/jumpbox/jumpbox.userdata
+++ b/modules/gcp/jumpbox/jumpbox.userdata
@@ -1,4 +1,8 @@
 #cloud-config
+repo_update: true
+repo_upgrade: all
+package_update: true
+package_upgrade: true
 packages:
   - language-pack-en
   - docker.io


### PR DESCRIPTION
…ures

apparently if the repo is unavailable the cloud-init install packages process mail fail, so the `package_update` ~ `apt update` is required to be set to `True` to work around it, also `repo_update` is set to `True` by default which is `package_update` but for AWS only(- https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/amazon-linux-ami-basics.html#amazon-linux-cloud-init) which apparently failed to work recently, so `package` directives have been added.

This is to avoid seeing the package fail to install under /var/log/cloud-init.log

```
9:14
2023-01-06 13:43:19,614 - util.py[DEBUG]: apt-install [eatmydata apt-get --option=Dpkg::Options::=--force-confold --option=Dpkg::options::=--force-unsafe-io --assume-yes --quiet install language-pack-en docker.io nginx tmux vim jq awscli skopeo] took 0.153 seconds
2023-01-06 13:43:19,614 - util.py[WARNING]: Failed to install packages: ['language-pack-en', 'docker.io', 'nginx', 'tmux', 'vim', 'jq', 'awscli', 'skopeo']
2023-01-06 13:43:19,614 - util.py[DEBUG]: Failed to install packages: ['language-pack-en', 'docker.io', 'nginx', 'tmux', 'vim', 'jq', 'awscli', 'skopeo']

Reading package lists...
W: Failed to fetch http://us-east-2.ec2.archive.ubuntu.com/ubuntu/dists/jammy/InRelease  503  Service Unavailable [IP: 52.15.102.108 80]
W: Failed to fetch http://us-east-2.ec2.archive.ubuntu.com/ubuntu/dists/jammy-updates/InRelease  503  Service Unavailable [IP: 52.15.102.108 80]
W: Failed to fetch http://us-east-2.ec2.archive.ubuntu.com/ubuntu/dists/jammy-backports/InRelease  503  Service Unavailable [IP: 52.15.102.108 80]
```