### PR TITLE
adding CSI driver for AWS EKS

### DIFF
--- a/modules/aws/k8s/main.tf
+++ b/modules/aws/k8s/main.tf
@@ -15,6 +15,9 @@ module "eks" {
   eks_managed_node_group_defaults = {
     disk_size      = 50
     instance_types = ["m5.xlarge"]
+    iam_role_additional_policies = {
+      AmazonEBSCSIDriverPolicy = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+    }
   }
 
   cluster_addons = {

--- a/modules/aws/k8s/main.tf
+++ b/modules/aws/k8s/main.tf
@@ -1,7 +1,7 @@
 data "aws_availability_zones" "available" {}
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 18.23.0"
+  version = "~> 19.0"
 
   cluster_name                    = var.cluster_name
   cluster_version                 = var.k8s_version
@@ -19,10 +19,17 @@ module "eks" {
 
   cluster_addons = {
     coredns = {
+      most_recent = true
       resolve_conflicts = "OVERWRITE"
     }
-    kube-proxy = {}
+    kube-proxy = {
+      most_recent = true
+    }
+    aws-ebs-csi-driver = {
+      most_recent = true
+    }
     vpc-cni = {
+      most_recent = true
       resolve_conflicts = "OVERWRITE"
     }
   }


### PR DESCRIPTION
more details: https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi-migration-faq.html as it is required as part of 1.23, apparently was installed by default before...