### PR TITLE
Do not use `:` in Redis passwords

### DIFF
--- a/modules/addons/ratelimit/main.tf
+++ b/modules/addons/ratelimit/main.tf
@@ -15,6 +15,8 @@ provider "kubectl" {
 
 resource "random_password" "redis" {
   length = 16
+  # Do not use the ':' character here as it will be read as Basic Auth and tokenized as <user>:<password>
+  override_special = "!@#$%&*()-_=+[]{}<>?"
 }
 
 resource "helm_release" "redis" {


### PR DESCRIPTION
If password contains the `:` character it will be read as Base64 auth and split into username and password, leading to error like this in the `ratelimit-server`:

```
time="2023-01-09T17:31:24Z" level=warning msg="enabling authentication to redis on redis-master.tsb-ratelimit.svc.cluster.local:6379 with user i>chwmz"
creating redis connection error : WRONGPASS invalid username-password pair or user is disabled.
```