### PR TITLE
set OAP SW_CORE_PERSISTENT_PERIOD to 5

### DIFF
--- a/modules/tsb/cp/manifests/tsb/controlplane-values.yaml.tmpl
+++ b/modules/tsb/cp/manifests/tsb/controlplane-values.yaml.tmpl
@@ -66,9 +66,6 @@ spec:
       certManager:
         managed: EXTERNAL
     oap:
-        oap:
-          streamingLogEnabled: true
-
       streamingLogEnabled: true
       kubeSpec:
         deployment:

--- a/modules/tsb/cp/manifests/tsb/controlplane-values.yaml.tmpl
+++ b/modules/tsb/cp/manifests/tsb/controlplane-values.yaml.tmpl
@@ -66,7 +66,15 @@ spec:
       certManager:
         managed: EXTERNAL
     oap:
+        oap:
+          streamingLogEnabled: true
+
       streamingLogEnabled: true
+      kubeSpec:
+        deployment:
+          env:
+          - name: SW_CORE_PERSISTENT_PERIOD
+            value: "5"
     %{ if ratelimit_enabled }
     rateLimitServer:
       domain: local


### PR DESCRIPTION
as per 

```
Each OAP (MP and CP) has a period in which it "collects and flushes metrics"  in bulk.  This is to optimize performance and bandwidth 
By default it is 25s.  This is why there is such a delay in TSB UI.  However, for a demo env I drop that down to 5s so that metrics and topology changes appear nearly instantaneous
```

should we @nacx @gonzaloserrano @shamusx ?