### PR TITLE
Add External DNS add-on

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,7 @@ tsb_mp:  ## Deploys the TSB Management Plane
 		fqdn=`jq -r '.tsb_fqdn' ../../terraform.tfvars.json`; \
 		address=`jq -r "if .ingress_ip.value != \"\" then .ingress_ip.value else .ingress_hostname.value end" ../../outputs/terraform_outputs/terraform-tsb-mp.json`; \
 		terraform -chdir=../fqdn/$$cloud init; \
+		terraform -chdir=../fqdn/$$cloud apply ${terraform_apply_args} -var-file="../../../terraform.tfvars.json" -var=address=$$address -var=fqdn=$$fqdn; \
 		terraform workspace select default; \
 		cd "../.."; \
 		'

--- a/README.md
+++ b/README.md
@@ -14,16 +14,22 @@ The `Makefile` in this directory provides ability to fastforward to anypoint of 
 
 ```mermaid
   graph TD;
-      A[make tsb] --> B[make k8s]
-      B[make k8s] --> C[make aws_k8s]
-      B[make k8s] --> CC[make azure_k8s]
-      B[make k8s] --> CCC[make gcp_k8s]
-      C[make aws_k8s] --> D[make tsb_mp]
-      CC[make azure_k8s] --> D[make tsb_mp]
-      CCC[make gcp_k8s] --> D[make tsb_mp]
-      D[make tsb_mp] --> DD[make tsb_cp]
-      D[make tsb_mp] --> G[make argocd]
-      D[make tsb_mp] --> H[make monitoring]
+      tsb[make tsb] --> k8s[make k8s]
+      k8s --> aws[make aws_k8s]
+      k8s --> azure[make azure_k8s]
+      k8s --> gcp[make gcp_k8s]
+      aws --> mp[make tsb_mp]
+      azure --> mp
+      gcp --> mp
+      mp --> cp[make tsb_cp]
+      subgraph Add-Ons
+        monitoring[make monitoring]
+        argocd[make argocd]
+        external-dns[make external-dns]
+      end
+      cp --> argocd
+      cp --> external-dns
+      mp --> monitoring
 ```
 
 # Getting Started

--- a/addons/README.md
+++ b/addons/README.md
@@ -12,7 +12,7 @@
 Deploy Argo CD for gitops demo
 
 ```bash
-# Deploys Argocd on all Clusters
+# Deploys Argo CD on all clusters
 make argocd
 ```
 
@@ -21,6 +21,16 @@ and the password can be found in the `outputs/terraform_outputs/terraform-argocd
 (defaults to the `tsb_password` if set).
 
 For details about the deployed applications, take a look at the manifests in the `applications` folder.
+
+## External DNS
+
+Deploy External DNS in each cluster to automatically watch Istio Gateways and register the
+public hostnames in the DNS provider.
+
+```bash
+# Deploys External DNS on all clusters
+make external-dns
+```
 
 ## TSB monitoring stack
 
@@ -39,10 +49,14 @@ in the `tsb-monitoring` namespace. The username is `admin` and the password can 
 ### Module Overview
 
 #### module.argocd (`make argocd`)
-* Deploys ArgoCD
+* Deploys ArgoCD on all clusters.
 * bookinfo demo app using ArgoCD with related TSB components.
 * grpc demo app using ArgoCD with related TSB components.
 * eshop demo app using ArgoCD with related TSB components.
+
+#### module.external-dns (`make external-dns`)
+* Deploys External DNS on all clusters.
+* configures it to watch Istio Gateways.
 
 #### module.monitoring (`make monitoring`)
 * Deploys the TSB monitoring stack.

--- a/addons/external-dns/gcp/credentials/main.tf
+++ b/addons/external-dns/gcp/credentials/main.tf
@@ -1,0 +1,25 @@
+data "terraform_remote_state" "infra" {
+  backend = "local"
+  config = {
+    path = "../../../../infra/gcp/terraform.tfstate.d/gcp-${var.tsb_mp["cluster_id"]}-${var.gcp_k8s_regions[tonumber(var.tsb_mp["cluster_id"])]}/terraform.tfstate"
+  }
+}
+
+locals {
+  dns_project = endswith(var.tsb_fqdn, ".gcp.cx.tetrate.info") ? "dns-terraform-sandbox" : data.terraform_remote_state.infra.outputs.project_id
+}
+
+resource "google_service_account" "external_dns" {
+  project = local.dns_project
+  account_id = "${var.name_prefix}-external-dns"
+}
+
+resource "google_project_iam_member" "dns_admin" {
+  project = local.dns_project
+  role = "roles/dns.admin"
+  member = "serviceAccount:${google_service_account.external_dns.email}"
+}
+
+resource "google_service_account_key" "external_dns_key" {
+  service_account_id = google_service_account.external_dns.name
+}

--- a/addons/external-dns/gcp/credentials/outputs.tf
+++ b/addons/external-dns/gcp/credentials/outputs.tf
@@ -1,0 +1,8 @@
+output "dns_project" {
+  value = local.dns_project
+}
+
+output "dns_credentials" {
+  value     = base64decode(google_service_account_key.external_dns_key.private_key)
+  sensitive = true
+}

--- a/addons/external-dns/gcp/credentials/variables.tf
+++ b/addons/external-dns/gcp/credentials/variables.tf
@@ -1,0 +1,16 @@
+variable "name_prefix" {
+}
+
+variable "tsb_fqdn" {
+}
+
+variable "tsb_mp" {
+  default = {
+    cloud      = "gcp"
+    cluster_id = 0
+  }
+}
+
+variable "gcp_k8s_regions" {
+  default = []
+}

--- a/addons/external-dns/gcp/main.tf
+++ b/addons/external-dns/gcp/main.tf
@@ -20,7 +20,7 @@ module "external_dns" {
   k8s_client_token           = data.terraform_remote_state.infra.outputs.token
   dns_provider               = "google"
   tsb_fqdn                   = var.tsb_fqdn
-  dns_zone                   = replace(var.tsb_fqdn, "/^[^\\.]+\\./", "")  # Remove the first aprt of the fqdn
+  dns_zone                   = replace(var.tsb_fqdn, "/^[^\\.]+\\./", "")  # Remove the first part of the fqdn
   google_project             = data.terraform_remote_state.dns.outputs.dns_project
   google_service_account_key = data.terraform_remote_state.dns.outputs.dns_credentials
 }

--- a/addons/external-dns/gcp/main.tf
+++ b/addons/external-dns/gcp/main.tf
@@ -1,0 +1,26 @@
+data "terraform_remote_state" "infra" {
+  backend = "local"
+  config = {
+    path = "../../../infra/gcp/terraform.tfstate.d/gcp-${var.cluster_id}-${var.gcp_k8s_regions[var.cluster_id]}/terraform.tfstate"
+  }
+}
+
+data "terraform_remote_state" "dns" {
+  backend = "local"
+  config = {
+    path = "credentials/terraform.tfstate"
+  }
+}
+
+module "external_dns" {
+  source                     = "../../../modules/addons/external-dns"
+  cluster_name               = data.terraform_remote_state.infra.outputs.cluster_name
+  k8s_host                   = data.terraform_remote_state.infra.outputs.host
+  k8s_cluster_ca_certificate = data.terraform_remote_state.infra.outputs.cluster_ca_certificate
+  k8s_client_token           = data.terraform_remote_state.infra.outputs.token
+  dns_provider               = "google"
+  tsb_fqdn                   = var.tsb_fqdn
+  dns_zone                   = replace(var.tsb_fqdn, "/^[^\\.]+\\./", "")  # Remove the first aprt of the fqdn
+  google_project             = data.terraform_remote_state.dns.outputs.dns_project
+  google_service_account_key = data.terraform_remote_state.dns.outputs.dns_credentials
+}

--- a/addons/external-dns/gcp/variables.tf
+++ b/addons/external-dns/gcp/variables.tf
@@ -1,0 +1,10 @@
+variable "cluster_id" {
+  default = null
+}
+
+variable "tsb_fqdn" {
+}
+
+variable "gcp_k8s_regions" {
+  default = []
+}

--- a/modules/addons/external-dns/main.tf
+++ b/modules/addons/external-dns/main.tf
@@ -1,0 +1,23 @@
+provider "helm" {
+  kubernetes {
+    host                   = var.k8s_host
+    cluster_ca_certificate = base64decode(var.k8s_cluster_ca_certificate)
+    token                  = var.k8s_client_token
+  }
+}
+
+resource "helm_release" "external_dns" {
+  name             = "external-dns"
+  repository       = "https://charts.bitnami.com/bitnami"
+  chart            = "external-dns"
+  create_namespace = true
+  namespace        = "external-dns"
+  timeout          = 900
+
+  values = [templatefile("${path.module}/manifests/values-${var.dns_provider}.yaml.tmpl", {
+    dns_zone                   = var.dns_zone
+    dns_owner_id               = var.cluster_name
+    google_project             = var.google_project
+    google_service_account_key = indent(4, var.google_service_account_key)
+  })]
+}

--- a/modules/addons/external-dns/main.tf
+++ b/modules/addons/external-dns/main.tf
@@ -14,9 +14,35 @@ resource "helm_release" "external_dns" {
   namespace        = "external-dns"
   timeout          = 900
 
+  set {
+    name  = "policy"
+    value = "upsert-only"
+  }
+
+  set {
+    name  = "registry"
+    value = "txt"
+  }
+
+  set {
+    name  = "txtOwnerId"
+    value = var.cluster_name
+  }
+
+  # Since we are enabling the Istio Gateway source, it is important to set this filter
+  # so we don't create DNS records for any random or internal hostnames defined in
+  # the TSB IngressGateways.
+  set {
+    name  = "domainFilters"
+    value = "{${var.dns_zone}}"
+  }
+
+  set {
+    name  = "sources"
+    value = "{service,ingress,istio-gateway}"
+  }
+
   values = [templatefile("${path.module}/manifests/values-${var.dns_provider}.yaml.tmpl", {
-    dns_zone                   = var.dns_zone
-    dns_owner_id               = var.cluster_name
     google_project             = var.google_project
     google_service_account_key = indent(4, var.google_service_account_key)
   })]

--- a/modules/addons/external-dns/manifests/values-google.yaml.tmpl
+++ b/modules/addons/external-dns/manifests/values-google.yaml.tmpl
@@ -1,0 +1,21 @@
+
+policy: upsert-only
+registry: txt
+txtOwnerId: ${dns_owner_id}
+
+# Since we are enabling the Istio Gateway source, it is important to set this filter
+# so we don't create DNS records for any random or internal hostnames defined in
+# the TSB IngressGateways.
+domainFilters:
+  - ${dns_zone}
+
+sources:
+  - service
+  - ingress
+  - istio-gateway
+
+provider: google
+google:
+  project: ${google_project}
+  serviceAccountKey: |
+    ${google_service_account_key}

--- a/modules/addons/external-dns/manifests/values-google.yaml.tmpl
+++ b/modules/addons/external-dns/manifests/values-google.yaml.tmpl
@@ -1,19 +1,3 @@
-
-policy: upsert-only
-registry: txt
-txtOwnerId: ${dns_owner_id}
-
-# Since we are enabling the Istio Gateway source, it is important to set this filter
-# so we don't create DNS records for any random or internal hostnames defined in
-# the TSB IngressGateways.
-domainFilters:
-  - ${dns_zone}
-
-sources:
-  - service
-  - ingress
-  - istio-gateway
-
 provider: google
 google:
   project: ${google_project}

--- a/modules/addons/external-dns/variables.tf
+++ b/modules/addons/external-dns/variables.tf
@@ -1,0 +1,32 @@
+variable "cluster_name" {
+}
+
+variable "k8s_host" {
+}
+
+variable "k8s_cluster_ca_certificate" {
+}
+
+variable "k8s_client_token" {
+}
+
+variable "tsb_fqdn" {
+}
+
+variable "dns_provider" {
+}
+
+variable "dns_zone" {
+}
+
+# Provider specific variables. All of them should be optional to allow
+# configuring only the ones for the provider being used.
+
+variable "google_project" {
+  default = ""
+}
+
+variable "google_service_account_key" {
+  default = ""
+  description = "Contents of the service account key JSON file"
+}


### PR DESCRIPTION
Adds an ExternalDNS add-on to automatically configure the DNS names for applications exposed in TSB Ingress gateways. It is default configured to watch the Istio Gateways so that ingress gateways created by TSB will be automatically configured in the DNS. Proper filters have been configured so that only hostnames exposed in the same DNS zone than the MP DNS-name will be generated, to avoid generating DNS records for internal hostnames, etc.

Currently, it only adds it for GCP, but the generic add-on module is already prepared to accommodate the other cloud providers. The only thing that needs to be added to the generic add-on is the provider-specific values file and the provider-specific variables.

Since external-dns requires credentials to update the DNS records and that's different in each cloud provider, I've built it as follows:

* The generic `modules/addons/external-dns` module will accept the variables for all providers as optional, sot aht each instance can set what's needed.
* There is a module for each cloud provider in the `addons/external-dns` folder so that we can instantiate the generic module with the right values for each provider.
* Inside the provider-specific module, there is a `credentials` module to create the credentials to manage DNS records in the cloud provider. This is a separate module because it should run only once to create the service account / whatever in the provider and store the key locally in the TF outputs. Once that's done, external-dns will be configured in each cluster with those credentials.