### PR TITLE
Allow enabling mesh internal identity propagation

### DIFF
--- a/modules/tsb/cp/main.tf
+++ b/modules/tsb/cp/main.tf
@@ -77,18 +77,18 @@ resource "helm_release" "controlplane" {
   timeout             = 900
 
   values = [templatefile("${path.module}/manifests/tsb/controlplane-values.yaml.tmpl", {
-    registry                  = var.registry
-    tsb_version               = var.tsb_version
-    tsb_fqdn                  = var.tsb_fqdn
-    cluster_name              = var.cluster_name
-    serviceaccount_clusterfqn = "organizations/${var.tsb_org}/clusters/${var.cluster_name}"
-    serviceaccount_jwk        = data.local_file.service_account.content
-    es_host                   = var.es_host
-    es_username               = var.es_username
-    es_password               = var.es_password
-    ratelimit_enabled         = var.ratelimit_enabled
-    ratelimit_namespace       = var.ratelimit_namespace
-    id_propagation_enabled    = var.id_propagation_enabled
+    registry                        = var.registry
+    tsb_version                     = var.tsb_version
+    tsb_fqdn                        = var.tsb_fqdn
+    cluster_name                    = var.cluster_name
+    serviceaccount_clusterfqn       = "organizations/${var.tsb_org}/clusters/${var.cluster_name}"
+    serviceaccount_jwk              = data.local_file.service_account.content
+    es_host                         = var.es_host
+    es_username                     = var.es_username
+    es_password                     = var.es_password
+    ratelimit_enabled               = var.ratelimit_enabled
+    ratelimit_namespace             = var.ratelimit_namespace
+    identity_propagation_enabled    = var.identity_propagation_enabled
   })]
 
   set {

--- a/modules/tsb/cp/main.tf
+++ b/modules/tsb/cp/main.tf
@@ -88,6 +88,7 @@ resource "helm_release" "controlplane" {
     es_password               = var.es_password
     ratelimit_enabled         = var.ratelimit_enabled
     ratelimit_namespace       = var.ratelimit_namespace
+    id_propagation_enabled    = var.id_propagation_enabled
   })]
 
   set {

--- a/modules/tsb/cp/manifests/tsb/controlplane-values.yaml.tmpl
+++ b/modules/tsb/cp/manifests/tsb/controlplane-values.yaml.tmpl
@@ -38,9 +38,7 @@ spec:
     xcp:
       centralAuthMode: JWT
       configProtection: {}
-      %{ if id_propagation_enabled }
-      enableHttpMeshInternalIdentityPropagation: true
-      %{ endif }
+      enableHttpMeshInternalIdentityPropagation: ${identity_propagation_enabled}
       kubeSpec:
         deployment:
           env:

--- a/modules/tsb/cp/manifests/tsb/controlplane-values.yaml.tmpl
+++ b/modules/tsb/cp/manifests/tsb/controlplane-values.yaml.tmpl
@@ -9,6 +9,10 @@ secrets:
     JWK: '${serviceaccount_jwk}'
 spec:
   hub: ${registry}
+  %{ if id_propagation_enabled }
+  imagePullSecrets:
+  - name: cr-pull-secret
+  %{ endif }
   telemetryStore:
     elastic:
       host: ${es_host}
@@ -34,7 +38,9 @@ spec:
     xcp:
       centralAuthMode: JWT
       configProtection: {}
-      enableHttpMeshInternalIdentityPropagation: false
+      %{ if id_propagation_enabled }
+      enableHttpMeshInternalIdentityPropagation: true
+      %{ endif }
       kubeSpec:
         deployment:
           env:

--- a/modules/tsb/cp/manifests/tsb/controlplane-values.yaml.tmpl
+++ b/modules/tsb/cp/manifests/tsb/controlplane-values.yaml.tmpl
@@ -9,7 +9,7 @@ secrets:
     JWK: '${serviceaccount_jwk}'
 spec:
   hub: ${registry}
-  %{ if id_propagation_enabled }
+  %{ if identity_propagation_enabled }
   imagePullSecrets:
   - name: cr-pull-secret
   %{ endif }

--- a/modules/tsb/cp/variables.tf
+++ b/modules/tsb/cp/variables.tf
@@ -112,3 +112,5 @@ variable "redis_password" {
 variable "output_path" {
 }
 
+variable "id_propagation_enabled" {
+}

--- a/modules/tsb/cp/variables.tf
+++ b/modules/tsb/cp/variables.tf
@@ -112,5 +112,5 @@ variable "redis_password" {
 variable "output_path" {
 }
 
-variable "id_propagation_enabled" {
+variable "identity_propagation_enabled" {
 }

--- a/tsb/cp/main.tf
+++ b/tsb/cp/main.tf
@@ -52,7 +52,7 @@ module "tsb_cp" {
   ratelimit_enabled               = var.ratelimit_enabled
   ratelimit_namespace             = module.ratelimit.namespace
   redis_password                  = module.ratelimit.redis_password
-  id_propagation_enabled          = var.id_propagation_enabled
+  identity_propagation_enabled    = var.identity_propagation_enabled
   istiod_cacerts_tls_crt          = data.terraform_remote_state.tsb_mp.outputs.istiod_cacerts_tls_crt
   istiod_cacerts_tls_key          = data.terraform_remote_state.tsb_mp.outputs.istiod_cacerts_tls_key
   tsb_image_sync_username         = var.tsb_image_sync_username

--- a/tsb/cp/main.tf
+++ b/tsb/cp/main.tf
@@ -52,6 +52,7 @@ module "tsb_cp" {
   ratelimit_enabled               = var.ratelimit_enabled
   ratelimit_namespace             = module.ratelimit.namespace
   redis_password                  = module.ratelimit.redis_password
+  id_propagation_enabled          = var.id_propagation_enabled
   istiod_cacerts_tls_crt          = data.terraform_remote_state.tsb_mp.outputs.istiod_cacerts_tls_crt
   istiod_cacerts_tls_key          = data.terraform_remote_state.tsb_mp.outputs.istiod_cacerts_tls_key
   tsb_image_sync_username         = var.tsb_image_sync_username

--- a/tsb/cp/variables.tf
+++ b/tsb/cp/variables.tf
@@ -136,3 +136,7 @@ variable "cert-manager_enabled" {
 variable "ratelimit_enabled" {
   default = true
 }
+
+variable "id_propagation_enabled" {
+  default = false
+}

--- a/tsb/cp/variables.tf
+++ b/tsb/cp/variables.tf
@@ -137,6 +137,6 @@ variable "ratelimit_enabled" {
   default = true
 }
 
-variable "id_propagation_enabled" {
+variable "identity_propagation_enabled" {
   default = false
 }


### PR DESCRIPTION
Addressing https://github.com/tetrateio/tetrate-service-bridge-sandbox/issues/225

`cr-pull-secret` has to be refreshed periodically for `AWS`, `cr-pull-secret` PR: https://github.com/tetrateio/tetrate-service-bridge-sandbox/pull/164

More details around secret management caveats: https://github.com/tetrateio/xcp/issues/2001