### PR TITLE
Configure the EBS CSI add-on to tag the created volumes

### DIFF
--- a/modules/aws/k8s/main.tf
+++ b/modules/aws/k8s/main.tf
@@ -34,6 +34,13 @@ module "eks" {
     }
     aws-ebs-csi-driver = {
       most_recent = true
+      configuration_values = <<EOT
+        {
+          "controller": {
+            "extraVolumeTags": ${jsonencode(var.tags)}
+          }
+        }
+      EOT
     }
     vpc-cni = {
       most_recent = true


### PR DESCRIPTION
Opened as a draft because it's not yet fully tested. I've created the cluster and I can see the add-on configuration is there, but I haven't been able to complete it because I'm hitting the issue:
```
 creating IAM OIDC Provider: LimitExceeded: Cannot exceed quota for OpenIdConnectProvidersPerAccount: 100
 ```
Once some providers are cleaned up, I'll complete the test and verify that the EBS volumes are properly tagged, then promote to ready for review.