### PR TITLE
Fix AWS jumpbox regexp

### DIFF
--- a/modules/aws/jumpbox/main.tf
+++ b/modules/aws/jumpbox/main.tf
@@ -290,14 +290,14 @@ resource "null_resource" "aws_cleanup" {
 
 resource "local_file" "tsbadmin_pem" {
   content         = tls_private_key.generated.private_key_pem
-  filename        = "${var.output_path}/${regex("\\w+-\\d","${var.name_prefix}")}-aws-${var.jumpbox_username}.pem"
+  filename        = "${var.output_path}/${regex(".+-\\d+","${var.name_prefix}")}-aws-${var.jumpbox_username}.pem"
   depends_on      = [tls_private_key.generated]
   file_permission = "0600"
 }
 
 resource "local_file" "ssh_jumpbox" {
-  content         = "ssh -i ${regex("\\w+-\\d","${var.name_prefix}")}-aws-${var.jumpbox_username}.pem -l ${var.jumpbox_username} ${aws_instance.jumpbox.public_ip}"
-  filename        = "${var.output_path}/ssh-to-aws-${regex("\\w+-\\d","${var.name_prefix}")}-jumpbox.sh"
+  content         = "ssh -i ${regex(".+-\\d+","${var.name_prefix}")}-aws-${var.jumpbox_username}.pem -l ${var.jumpbox_username} ${aws_instance.jumpbox.public_ip}"
+  filename        = "${var.output_path}/ssh-to-aws-${regex(".+-\\d+","${var.name_prefix}")}-jumpbox.sh"
   file_permission = "0755"
 }
 


### PR DESCRIPTION
Fixes #236 

This fixes the regular expression introduced in https://github.com/tetrateio/tetrate-service-bridge-sandbox/commit/d406667b515d2278d99d1b60e27e2e93e4088176.

I haven't tried deploying an AWS environment but verified that it works with different values here: https://regex101.com/r/wjzQ0N/2
@kurktchiev feel free to try it.
