### PR TITLE
Default tags are broken in the AWS terraform upstream provider

### DIFF
--- a/infra/aws/main.tf
+++ b/infra/aws/main.tf
@@ -1,9 +1,14 @@
 provider "aws" {
   region = var.aws_k8s_region
-  default_tags {
-    tags = local.default_tags
-  }
+
+  # Re-enable this once https://github.com/hashicorp/terraform-provider-aws/issues/19583
+  # is fixed. Until then, the workaround is to manually merge
+  # the tags in every resource.
+  # default_tags {
+  #   tags = local.default_tags
+  # }
 }
+
 resource "random_string" "random_id" {
   length  = 4
   special = false
@@ -11,12 +16,15 @@ resource "random_string" "random_id" {
   upper   = false
   numeric = false
 }
+
 module "aws_base" {
   source      = "../../modules/aws/base"
   count       = var.aws_k8s_region == null ? 0 : 1
   name_prefix = "${var.name_prefix}-${var.cluster_id}-${random_string.random_id.result}"
   cidr        = cidrsubnet(var.cidr, 4, 4 + tonumber(var.cluster_id))
+  tags        = local.default_tags
 }
+
 module "aws_jumpbox" {
   source                    = "../../modules/aws/jumpbox"
   count                     = var.aws_k8s_region == null ? 0 : 1

--- a/modules/aws/base/main.tf
+++ b/modules/aws/base/main.tf
@@ -1,9 +1,9 @@
 resource "aws_vpc" "tsb" {
   cidr_block           = var.cidr
   enable_dns_hostnames = true
-  tags = {
+  tags = merge(var.tags, {
     Name = "${var.name_prefix}_vpc"
-  }
+  })
 }
 
 data "aws_availability_zones" "available" {}
@@ -14,16 +14,16 @@ resource "aws_subnet" "tsb" {
   cidr_block              = cidrsubnet(var.cidr, 4, count.index)
   vpc_id                  = aws_vpc.tsb.id
   map_public_ip_on_launch = "true"
-  tags = {
+  tags = merge(var.tags, {
     Name = "${var.name_prefix}_subnet_${data.aws_availability_zones.available.names[count.index]}"
-  }
+  })
 }
 
 resource "aws_internet_gateway" "tsb" {
   vpc_id = aws_vpc.tsb.id
-  tags = {
+  tags = merge(var.tags, {
     Name = "${var.name_prefix}_igw"
-  }
+  })
 }
 
 
@@ -35,9 +35,9 @@ resource "aws_route_table" "rt" {
     gateway_id = aws_internet_gateway.tsb.id
   }
 
-  tags = {
+  tags = merge(var.tags, {
     Name = "${var.name_prefix}_rt"
-  }
+  })
 }
 
 
@@ -60,9 +60,9 @@ resource "aws_ecr_repository" "tsb" {
     scan_on_push = true
   }
 
-  tags = {
+  tags = merge(var.tags, {
     Name = "${var.name_prefix}_ecr"
-  }
+  })
 }
 
 data "aws_ecr_authorization_token" "token" {

--- a/modules/aws/base/variables.tf
+++ b/modules/aws/base/variables.tf
@@ -13,3 +13,7 @@ variable "min_az_count" {
 variable "max_az_count" {
   default = 3
 }
+
+variable "tags" {
+  type = map
+}

--- a/modules/aws/jumpbox/main.tf
+++ b/modules/aws/jumpbox/main.tf
@@ -2,9 +2,9 @@ resource "aws_security_group" "jumpbox_sg" {
   description = "Allow incoming connections to the lab jumpbox."
   vpc_id      = var.vpc_id
 
-  tags = {
+  tags = merge(var.tags, {
     Name = "${var.name_prefix}_jumpbox_sg"
-  }
+  })
 
   ingress {
     from_port   = 22
@@ -177,18 +177,18 @@ resource "aws_iam_role" "jumpbox_iam_role" {
   ]
 }
 EOF
-  tags = {
+  tags = merge(var.tags, {
     Name = "${var.name_prefix}_jumpbox_iam_role"
-  }
+  })
 }
 
 resource "aws_iam_instance_profile" "jumpbox_iam_profile" {
   name = "${var.name_prefix}_jumpbox_profile"
   role = aws_iam_role.jumpbox_iam_role.name
 
-  tags = {
+  tags = merge(var.tags, {
     Name = "${var.name_prefix}_jumpbox_profile"
-  }
+  })
 }
 
 
@@ -203,9 +203,9 @@ resource "aws_key_pair" "tsbadmin_key_pair" {
   key_name   = "${var.name_prefix}_generated"
   public_key = tls_private_key.generated.public_key_openssh
 
-  tags = {
+  tags = merge(var.tags, {
     Name = "${var.name_prefix}_tsbadmin_key"
-  }
+  })
 }
 
 data "aws_ami" "ubuntu" {
@@ -263,9 +263,9 @@ resource "aws_instance" "jumpbox" {
   }))
   iam_instance_profile = aws_iam_instance_profile.jumpbox_iam_profile.name
 
-  tags = {
+  tags = merge(var.tags, {
     Name = "${var.name_prefix}_jumpbox"
-  }
+  })
 
   volume_tags = merge(var.tags, {
     Name = "${var.name_prefix}_jumpbox"


### PR DESCRIPTION
Do not use default tags until https://github.com/hashicorp/terraform-provider-aws/issues/19583 is fixed, as they are being recomputed all the time, and giving errors on the first run.