### PR TITLE
Fix EKS EBS add-on configuration

### DIFF
--- a/modules/aws/k8s/main.tf
+++ b/modules/aws/k8s/main.tf
@@ -34,13 +34,11 @@ module "eks" {
     }
     aws-ebs-csi-driver = {
       most_recent = true
-      configuration_values = <<EOT
-        {
-          "controller": {
-            "extraVolumeTags": ${jsonencode(var.tags)}
-          }
+      configuration_values = jsonencode({
+        "controller" = {
+          "extraVolumeTags" = var.tags
         }
-      EOT
+      })
     }
     vpc-cni = {
       most_recent = true


### PR DESCRIPTION
By passing the string manually, subsequent runs triggered a modification of the add-on just because of whitespace. This produces a consistent non-whitespace thing that doesn't trigger add-on reconfigurations.