### PR TITLE
Remove wrong k8s node group

### DIFF
--- a/modules/aws/k8s/main.tf
+++ b/modules/aws/k8s/main.tf
@@ -54,9 +54,6 @@ module "eks" {
       max_size     = 5
       desired_size = 3
     }
-    tags = merge(var.tags, {
-      Name = "${var.name_prefix}_sandbox_blue"
-    })
   }
 
   cluster_security_group_additional_rules = {


### PR DESCRIPTION
The `eks_managed_node_groups` block inside the `eks` module does _not_ have a `tags` element. With that, it was creating a node group named `tags` with the corresponding useless instance and consumed resources.