### PR TITLE
Cache the internal CR token to avoid jumbox reconciliations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,8 +210,7 @@ destroy_%:
 
 .PHONY: destroy_tfstate
 destroy_tfstate:
-	find . -name terraform.tfstate.d -exec rm -rf {} +
-	find . -name terraform.tfstate -delete
+	find . -name *tfstate* -exec rm -rf {} +
 
 .PHONY: destroy_tfcache
 destroy_tfcache:

--- a/modules/aws/jumpbox/main.tf
+++ b/modules/aws/jumpbox/main.tf
@@ -230,6 +230,14 @@ data "aws_availability_zones" "available" {}
 module "internal_registry" {
   source      = "../../internal_registry"
   tsb_version = var.tsb_version
+  # The internal registry token is needed only if the TSB version is a development version, and only once when the
+  # jumpbox bootstraps the first time. It is not needed later as all images are already pushed to the registry (and
+  # cloud-init won't run again anyway).
+  # Since the token is short-lived, successive calls to this module would cause the jumpbox to reconcile, restart, and
+  # eventually changing the IP address, etc, unnecessarily.
+  # By setting this, subsequent calls to this module will return the token returned on the initial run, if present, avoiding
+  # the jumbox reconcile.
+  cached_by   = "${var.name_prefix}-internal-registry.tfstate.tokencache"
 }
 
 resource "aws_instance" "jumpbox" {

--- a/modules/azure/jumpbox/main.tf
+++ b/modules/azure/jumpbox/main.tf
@@ -96,6 +96,14 @@ resource "tls_private_key" "generated" {
 module "internal_registry" {
   source      = "../../internal_registry"
   tsb_version = var.tsb_version
+  # The internal registry token is needed only if the TSB version is a development version, and only once when the
+  # jumpbox bootstraps the first time. It is not needed later as all images are already pushed to the registry (and
+  # cloud-init won't run again anyway).
+  # Since the token is short-lived, successive calls to this module would cause the jumpbox to reconcile, restart, and
+  # eventually changing the IP address, etc, unnecessarily.
+  # By setting this, subsequent calls to this module will return the token returned on the initial run, if present, avoiding
+  # the jumbox reconcile.
+  cached_by   = "${var.name_prefix}-internal-registry.tfstate.tokencache"
 }
 
 resource "azurerm_linux_virtual_machine" "jumpbox" {

--- a/modules/gcp/jumpbox/main.tf
+++ b/modules/gcp/jumpbox/main.tf
@@ -26,6 +26,14 @@ data "google_compute_default_service_account" "default" {
 module "internal_registry" {
   source      = "../../internal_registry"
   tsb_version = var.tsb_version
+  # The internal registry token is needed only if the TSB version is a development version, and only once when the
+  # jumpbox bootstraps the first time. It is not needed later as all images are already pushed to the registry (and
+  # cloud-init won't run again anyway).
+  # Since the token is short-lived, successive calls to this module would cause the jumpbox to reconcile, restart, and
+  # eventually changing the IP address, etc, unnecessarily.
+  # By setting this, subsequent calls to this module will return the token returned on the initial run, if present, avoiding
+  # the jumbox reconcile.
+  cached_by   = "${var.name_prefix}-internal-registry.tfstate.tokencache"
 }
 
 resource "google_compute_instance" "jumpbox" {

--- a/modules/internal_registry/main.tf
+++ b/modules/internal_registry/main.tf
@@ -3,5 +3,6 @@ data "external" "gcr_token" {
   program = ["bash", "${path.module}/internal-cr-token.sh"]
   query = {
     "tsb_version" = var.tsb_version
+    "cached_by"   = var.cached_by
   }
 }

--- a/modules/internal_registry/variables.tf
+++ b/modules/internal_registry/variables.tf
@@ -1,2 +1,5 @@
 variable "tsb_version" {
 }
+variable "cached_by" {
+  default = ""
+}


### PR DESCRIPTION
Fixes https://github.com/tetrateio/tetrate-service-bridge-sandbox/issues/241

@smarunich this is an absolute hack, but WDYT about this?

The idea is that just because that module uses an external script and always runs, it's altering the suer-data and causing the jumpbox to reconcile, when that's useless because cloud-init is run only on the first boot; changes to user-data wouldn't even be considered.

This change basically caches the initial token in the local filesystem to return it in subsequent runs, and avoid that annoying reconcile that breaks the development version usage.

I also considered adding it as an output variable of the module and propagate the output so it can be cached in the terraform state, and read with the `terraform_remote_state` data provider, but that would fail on the first run when the key still does not exist, so I opted for the local (.git-ignored) file hack. WDYT?