### PR TITLE
Automatically configure a VM endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ azure_k8s: init  ## Deploys azure k8s cluster for MP and N-number of CPs(*) leve
 		cluster_name="aks-$$name_prefix-$$region-$$index"; \
 		echo "cloud=azure region=$$region cluster_id=$$index cluster_name=$$cluster_name"; \
 		cd "infra/azure"; \
-		terraform workspace new azure-$$index-$$region; \
+		terraform workspace new azure-$$index-$$region || true; \
 		terraform workspace select azure-$$index-$$region; \
 		terraform init; \
 		terraform apply ${terraform_apply_args} -target module.azure_base -var-file="../../terraform.tfvars.json" -var=azure_k8s_region=$$region -var=cluster_name=$$cluster_name -var=cluster_id=$$index; \
@@ -56,7 +56,7 @@ aws_k8s: init  ## Deploys EKS K8s cluster (CPs only)
 		cluster_name="eks-$$name_prefix-$$region-$$index"; \
 		echo "cloud=aws region=$$region cluster_id=$$index cluster_name=$$cluster_name"; \
 		cd "infra/aws"; \
-		terraform workspace new aws-$$index-$$region; \
+		terraform workspace new aws-$$index-$$region || true; \
 		terraform workspace select aws-$$index-$$region; \
 		terraform init; \
 		terraform apply ${terraform_apply_args} -var-file="../../terraform.tfvars.json" -var=aws_k8s_region=$$region -var=cluster_name=$$cluster_name -var=cluster_id=$$index; \
@@ -77,7 +77,7 @@ gcp_k8s: init  ## Deploys GKE K8s cluster (CPs only)
 		cluster_name="gke-$$name_prefix-$$region-$$index"; \
 		echo "cloud=gcp region=$$region cluster_id=$$index cluster_name=$$cluster_name"; \
 		cd "infra/gcp"; \
-		terraform workspace new gcp-$$index-$$region; \
+		terraform workspace new gcp-$$index-$$region || true; \
 		terraform workspace select gcp-$$index-$$region; \
 		terraform init; \
 		terraform apply ${terraform_apply_args} -target module.gcp_base -var-file="../../terraform.tfvars.json" -var=gcp_k8s_region=$$region -var=cluster_name=$$cluster_name -var=cluster_id=$$index; \
@@ -125,7 +125,7 @@ tsb_cp_%:
 		jq -r '.$*_k8s_regions[]' terraform.tfvars.json | while read -r region; do \
 		echo "cloud=$* region=$$region cluster_id=$$index"; \
 		cd "tsb/cp"; \
-		terraform workspace new $*-$$index-$$region; \
+		terraform workspace new $*-$$index-$$region || true; \
 		terraform workspace select $*-$$index-$$region; \
 		terraform init; \
 		terraform apply ${terraform_apply_args} -var-file="../../terraform.tfvars.json" -var=cloud=$* -var=cluster_id=$$index; \
@@ -150,7 +150,7 @@ argocd_%:
 		jq -r '.$*_k8s_regions[]' terraform.tfvars.json | while read -r region; do \
 		echo "cloud=$* region=$$region cluster_id=$$index"; \
 		cd "addons/argocd"; \
-		terraform workspace new $*-$$index-$$region; \
+		terraform workspace new $*-$$index-$$region || true; \
 		terraform workspace select $*-$$index-$$region; \
 		terraform init; \
 		terraform apply ${terraform_apply_args} -var-file="../../terraform.tfvars.json" -var=cloud=$* -var=cluster_id=$$index; \
@@ -187,7 +187,7 @@ external-dns_%:
 		jq -r '.$*_k8s_regions[]' terraform.tfvars.json | while read -r region; do \
 		echo "cloud=$* region=$$region cluster_id=$$index"; \
 		cd "addons/$*/external-dns"; \
-		terraform workspace new $*-$$index-$$region; \
+		terraform workspace new $*-$$index-$$region || true; \
 		terraform workspace select $*-$$index-$$region; \
 		terraform init; \
 		terraform apply ${terraform_apply_args} -var-file="../../../terraform.tfvars.json" -var=cloud=$* -var=cluster_id=$$index; \
@@ -207,7 +207,7 @@ destroy_external-dns_%:
 		jq -r '.$*_k8s_regions[]' terraform.tfvars.json | while read -r region; do \
 		echo "cloud=$* region=$$region cluster_id=$$index"; \
 		cd "addons/$*/external-dns"; \
-		terraform workspace new $*-$$index-$$region; \
+		terraform workspace new $*-$$index-$$region || true; \
 		terraform workspace select $*-$$index-$$region; \
 		terraform init; \
 		terraform destroy ${terraform_apply_args} -var-file="../../../terraform.tfvars.json" -var=cloud=$* -var=cluster_id=$$index; \

--- a/modules/tsb/cp/main.tf
+++ b/modules/tsb/cp/main.tf
@@ -89,6 +89,7 @@ resource "helm_release" "controlplane" {
     ratelimit_enabled               = var.ratelimit_enabled
     ratelimit_namespace             = var.ratelimit_namespace
     identity_propagation_enabled    = var.identity_propagation_enabled
+    vm_endpoint                     = "vms.${var.cluster_name}.${regep("[^\\.]*\\.(.*)", var.tsb_fqdn)}"
   })]
 
   set {

--- a/modules/tsb/cp/manifests/cert-manager/vm-onboarding-cert.yaml.tmpl
+++ b/modules/tsb/cp/manifests/cert-manager/vm-onboarding-cert.yaml.tmpl
@@ -1,0 +1,16 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: vm-onboarding
+  namespace: istio-system
+spec:
+  secretName: vm-onboarding
+  duration: 21600h # 900d
+  usages:
+  - server auth
+  dnsNames:
+  - ${vm_endpoint}
+  issuerRef:
+    name: selfsigned-ca
+    kind: ClusterIssuer

--- a/modules/tsb/cp/manifests/tsb/controlplane-values.yaml.tmpl
+++ b/modules/tsb/cp/manifests/tsb/controlplane-values.yaml.tmpl
@@ -35,6 +35,15 @@ spec:
             patches:
               - path: spec.meshConfig.defaultConfig.holdApplicationUntilProxyStarts
                 value: true
+              - path: spec.components.ingressGateways[name:vmgateway].k8s.overlays[-1]
+                value:
+                  apiVersion: v1
+                  kind: Service
+                  name: vmgateway
+                  patches:
+                    - path: metadata.annotations
+                      value:
+                        external-dns.alpha.kubernetes.io/hostname: ${vm_endpoint}
     xcp:
       centralAuthMode: JWT
       configProtection: {}
@@ -78,7 +87,13 @@ spec:
         redis:
           uri: redis-master.${ratelimit_namespace}.svc.cluster.local:6379
     %{ endif }
-  meshExpansion: {}
+  meshExpansion:
+    onboarding:
+      localRepository: {}
+      endpoint:
+        hosts:
+          - ${vm_endpoint}
+        secretName: vm-onboarding
   meshObservability:
     settings:
       apiEndpointMetricsEnabled: true  

--- a/modules/tsb/cp/variables.tf
+++ b/modules/tsb/cp/variables.tf
@@ -114,3 +114,6 @@ variable "output_path" {
 
 variable "identity_propagation_enabled" {
 }
+
+variable "vm_endpoint" {
+}

--- a/tsb/cp/main.tf
+++ b/tsb/cp/main.tf
@@ -53,6 +53,7 @@ module "tsb_cp" {
   ratelimit_namespace             = module.ratelimit.namespace
   redis_password                  = module.ratelimit.redis_password
   identity_propagation_enabled    = var.identity_propagation_enabled
+  vm_endpoint                     = coalesce(var.vm_endpoint, "vms.${data.terraform_remote_state.infra.outputs.cluster_name}.${regex("[^\\.]*\\.(.*)", var.tsb_fqdn)}")
   istiod_cacerts_tls_crt          = data.terraform_remote_state.tsb_mp.outputs.istiod_cacerts_tls_crt
   istiod_cacerts_tls_key          = data.terraform_remote_state.tsb_mp.outputs.istiod_cacerts_tls_key
   tsb_image_sync_username         = var.tsb_image_sync_username

--- a/tsb/cp/variables.tf
+++ b/tsb/cp/variables.tf
@@ -142,5 +142,5 @@ variable "identity_propagation_enabled" {
 }
 
 variable "vm_endpoint" {
-  default = "vms.${var.cluster_name}.${regex("[^\\.]*\\.(.*)", var.tsb_fqdn)}"
+  default = null
 }

--- a/tsb/cp/variables.tf
+++ b/tsb/cp/variables.tf
@@ -140,3 +140,7 @@ variable "ratelimit_enabled" {
 variable "identity_propagation_enabled" {
   default = false
 }
+
+variable "vm_endpoint" {
+  default = "vms.${var.cluster_name}.${regep("[^\\.]*\\.(.*)", var.tsb_fqdn)}"
+}

--- a/tsb/cp/variables.tf
+++ b/tsb/cp/variables.tf
@@ -142,5 +142,5 @@ variable "identity_propagation_enabled" {
 }
 
 variable "vm_endpoint" {
-  default = "vms.${var.cluster_name}.${regep("[^\\.]*\\.(.*)", var.tsb_fqdn)}"
+  default = "vms.${var.cluster_name}.${regex("[^\\.]*\\.(.*)", var.tsb_fqdn)}"
 }


### PR DESCRIPTION
Fixes https://github.com/tetrateio/tetrate-service-bridge-sandbox/issues/184

Now that we can install external-dns we can automatically configure the VM endpoint.