### PR TITLE
Remove extra `)` in tetrate_owner

### DIFF
--- a/infra/gcp/variables.tf
+++ b/infra/gcp/variables.tf
@@ -120,7 +120,7 @@ variable "tetrate_customer" {
 }
 locals {
   default_tags = {
-       tetrate_owner     = replace(coalesce(var.tetrate_owner, var.tsb_image_sync_username), "/\\W+/", "_"))
+       tetrate_owner     = replace(coalesce(var.tetrate_owner, var.tsb_image_sync_username), "/\\W+/", "_")
        tetrate_team      = replace(var.tetrate_team, "/\\W+/", "_")
        tetrate_purpose   = var.tetrate_purpose
        tetrate_lifespan  = var.tetrate_lifespan


### PR DESCRIPTION
Address a typo introduced as part of **https://github.com/tetrateio/tetrate-service-bridge-sandbox/pull/261**