### PR TITLE
modified tfvars.json.sample for mp-eks

### DIFF
--- a/tfvars_collection/mp-eks-cp-1aks-1eks-2gke.tfvars.json.sample
+++ b/tfvars_collection/mp-eks-cp-1aks-1eks-2gke.tfvars.json.sample
@@ -1,7 +1,7 @@
 {
     "name_prefix": "<YOUR UNIQUE PREFIX NAME TO BE CREATED>",
     "dns_provider": "aws",
-    "tsb_fqdn": "<YOUR UNIQUE PREFIX NAME TO BE CREATED>.sandbox.tetrate.io",
+    "tsb_fqdn": "<YOUR UNIQUE PREFIX NAME TO BE CREATED>.<YOUR_AWS_ACCT_PREFIX>.sandbox.tetrate.io",
     "tsb_version": "1.6.0",
     "tsb_image_sync_username": "<TSB_REPO_USERNAME>",
     "tsb_image_sync_apikey": "<TSB_REPO_APIKEY>",


### PR DESCRIPTION
Minor change:

added `<YOUR_AWS_ACCT_PREFIX>` to `"tsb_fqdn": "<YOUR UNIQUE PREFIX NAME TO BE CREATED>.<YOUR_AWS_ACCT_PREFIX>.sandbox.tetrate.io"` in  `mp-eks-cp-1aks-1eks-2gke.tfvars.json.sample` file to avoid this error:
```
Error: no matching Route53Zone found
│
│   with module.register_fqdn.data.aws_route53_zone.zone,
│   on ../../../modules/aws/register_fqdn/main.tf line 1, in data "aws_route53_zone" "zone":
│    1: data "aws_route53_zone" "zone" {
```

required for usage:
```
# Build full demo
make tsb
```
