### PR TITLE
Downgrade google provider version

### DIFF
--- a/infra/gcp/k8s_auth/providers.tf
+++ b/infra/gcp/k8s_auth/providers.tf
@@ -1,9 +1,5 @@
 terraform {
   required_providers {
-    kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.7.0"
-    } 
     google = {
       version = "~> 4.64.0"
     }


### PR DESCRIPTION
Work around: https://github.com/tetrateio/tetrate-service-bridge-sandbox/issues/275 and rollback when fix is available