### PR TITLE
Revert "Small helper to run remote commands"

### DIFF
--- a/modules/aws/jumpbox/main.tf
+++ b/modules/aws/jumpbox/main.tf
@@ -295,7 +295,7 @@ resource "local_file" "tsbadmin_pem" {
 }
 
 resource "local_file" "ssh_jumpbox" {
-  content         = "ssh -i ${regex(".+-\\d+","${var.name_prefix}")}-aws-${var.jumpbox_username}.pem -l ${var.jumpbox_username} ${aws_instance.jumpbox.public_ip}"
+  content         = "ssh -i ${regex(".+-\\d+","${var.name_prefix}")}-aws-${var.jumpbox_username}.pem -l ${var.jumpbox_username} ${aws_instance.jumpbox.public_ip} \"$@\""
   filename        = "${var.output_path}/ssh-to-aws-${regex(".+-\\d+","${var.name_prefix}")}-jumpbox.sh"
   file_permission = "0755"
 }

--- a/modules/aws/jumpbox/main.tf
+++ b/modules/aws/jumpbox/main.tf
@@ -295,7 +295,7 @@ resource "local_file" "tsbadmin_pem" {
 }
 
 resource "local_file" "ssh_jumpbox" {
-  content         = "ssh -i ${regex(".+-\\d+","${var.name_prefix}")}-aws-${var.jumpbox_username}.pem -l ${var.jumpbox_username} ${aws_instance.jumpbox.public_ip} \"@\""
+  content         = "ssh -i ${regex(".+-\\d+","${var.name_prefix}")}-aws-${var.jumpbox_username}.pem -l ${var.jumpbox_username} ${aws_instance.jumpbox.public_ip}"
   filename        = "${var.output_path}/ssh-to-aws-${regex(".+-\\d+","${var.name_prefix}")}-jumpbox.sh"
   file_permission = "0755"
 }

--- a/modules/azure/jumpbox/main.tf
+++ b/modules/azure/jumpbox/main.tf
@@ -169,7 +169,7 @@ resource "local_file" "tsbadmin_pem" {
 }
 
 resource "local_file" "ssh_jumpbox" {
-  content         = "ssh -i ${var.name_prefix}-azure-${var.jumpbox_username}.pem -l ${var.jumpbox_username} ${azurerm_public_ip.jumpbox_public_ip.ip_address} \"@\""
+  content         = "ssh -i ${var.name_prefix}-azure-${var.jumpbox_username}.pem -l ${var.jumpbox_username} ${azurerm_public_ip.jumpbox_public_ip.ip_address}"
   filename        = "${var.output_path}/ssh-to-azure-${var.name_prefix}-jumpbox.sh"
   file_permission = "0755"
 }

--- a/modules/azure/jumpbox/main.tf
+++ b/modules/azure/jumpbox/main.tf
@@ -169,7 +169,7 @@ resource "local_file" "tsbadmin_pem" {
 }
 
 resource "local_file" "ssh_jumpbox" {
-  content         = "ssh -i ${var.name_prefix}-azure-${var.jumpbox_username}.pem -l ${var.jumpbox_username} ${azurerm_public_ip.jumpbox_public_ip.ip_address}"
+  content         = "ssh -i ${var.name_prefix}-azure-${var.jumpbox_username}.pem -l ${var.jumpbox_username} ${azurerm_public_ip.jumpbox_public_ip.ip_address} \"$@\""
   filename        = "${var.output_path}/ssh-to-azure-${var.name_prefix}-jumpbox.sh"
   file_permission = "0755"
 }

--- a/modules/gcp/jumpbox/main.tf
+++ b/modules/gcp/jumpbox/main.tf
@@ -110,7 +110,7 @@ resource "local_file" "tsbadmin_pem" {
 }
 
 resource "local_file" "ssh_jumpbox" {
-  content         = "ssh -i ${var.name_prefix}-gcp-${var.jumpbox_username}.pem -l ${var.jumpbox_username} ${google_compute_instance.jumpbox.network_interface[0].access_config[0].nat_ip}"
+  content         = "ssh -i ${var.name_prefix}-gcp-${var.jumpbox_username}.pem -l ${var.jumpbox_username} ${google_compute_instance.jumpbox.network_interface[0].access_config[0].nat_ip} \"$@\""
   filename        = "${var.output_path}/ssh-to-gcp-${var.name_prefix}-jumpbox.sh"
   file_permission = "0755"
 }

--- a/modules/gcp/jumpbox/main.tf
+++ b/modules/gcp/jumpbox/main.tf
@@ -110,7 +110,7 @@ resource "local_file" "tsbadmin_pem" {
 }
 
 resource "local_file" "ssh_jumpbox" {
-  content         = "ssh -i ${var.name_prefix}-gcp-${var.jumpbox_username}.pem -l ${var.jumpbox_username} ${google_compute_instance.jumpbox.network_interface[0].access_config[0].nat_ip} \"@\""
+  content         = "ssh -i ${var.name_prefix}-gcp-${var.jumpbox_username}.pem -l ${var.jumpbox_username} ${google_compute_instance.jumpbox.network_interface[0].access_config[0].nat_ip}"
   filename        = "${var.output_path}/ssh-to-gcp-${var.name_prefix}-jumpbox.sh"
   file_permission = "0755"
 }


### PR DESCRIPTION
Reverts tetrateio/tetrate-service-bridge-sandbox#278

The existing functionality affected...

```
❯ cat ./ssh-to-aws-170tse3-0-jumpbox.sh
ssh -i 170tse3-0-aws-tetrate-admin.pem -l tetrate-admin 54.215.181.60 "@"
❯ ./ssh-to-aws-170tse3-0-jumpbox.sh
bash: line 1: @: command not found
```