### PR TITLE
application api example httpbin

### DIFF
--- a/gitops/opa-s2s-httpbin/httpbin-cert.yaml
+++ b/gitops/opa-s2s-httpbin/httpbin-cert.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: httpbin-cert
+  namespace: opa-s2s-httpbin
+spec:
+  secretName: httpbin-cert
+  duration: 21600h # 900d
+  issuerRef:
+    name: selfsigned-ca
+    kind: ClusterIssuer
+    group: cert-manager.io
+  dnsNames:
+    - "httpbin.tetrate.io"

--- a/gitops/opa-s2s-httpbin/tsb-s2s-httpbin.yaml
+++ b/gitops/opa-s2s-httpbin/tsb-s2s-httpbin.yaml
@@ -40,3 +40,70 @@ spec:
     http:
       external:
         uri: "grpc://127.0.0.1:9191"
+---        
+apiVersion: install.tetrate.io/v1alpha1
+kind: IngressGateway
+metadata:
+  name: opa-api-httpbin-gw
+  namespace: opa-s2s-httpbin
+spec:
+  kubeSpec:
+    service:
+      type: LoadBalancer
+---
+apiVersion: application.tsb.tetrate.io/v2
+kind: Application
+metadata:
+  name: opa-api-httpbin-app
+  annotations:
+    tsb.tetrate.io/organization: tetrate
+    tsb.tetrate.io/tenant: dev
+spec:
+  description: httpbin application
+  displayName: httpbin application
+  workspace: organizations/tetrate/tenants/dev/workspaces/opa-s2s-httpbin-ws
+---
+apiVersion: application.tsb.tetrate.io/v2
+kind: API
+metadata:
+  annotations:
+    tsb.tetrate.io/organization: tetrate
+    tsb.tetrate.io/tenant: dev
+    tsb.tetrate.io/application: opa-api-httpbin-app
+  name: opa-api-httpbin-gw
+spec:
+  description: Httpbin OpenAPI
+  workloadSelector:
+    namespace: opa-s2s-httpbin
+    labels:
+      app: opa-api-httpbin-gw
+  openapi: |
+    openapi: 3.0.1
+    info:
+      version: '1.0-oas3'
+      title: httpbin
+      description: An unofficial OpenAPI definition for httpbin
+      x-tsb-service: httpbin-with-opa.opa-s2s-httpbin
+
+    servers:
+      - url: https://httpbin.tetrate.io
+        x-tsb-cors:
+          allowOrigin:
+            - "*"
+        x-tsb-tls:
+          mode: SIMPLE
+          secretName: httpbin-cert
+    paths:
+      /get:
+        get:
+          tags:
+            - HTTP methods
+          summary: |
+            Returns the GET request's data.
+          responses:
+            '200': 
+              description: OK
+              content:
+                application/json:
+                  schema:
+                    type: object


### PR DESCRIPTION
externalize opa-s2s-httpbin as API Application
https://docs.tetrate.io/service-bridge/1.4.x/howto/application_gateway_with_openapi_annotations#configure-the-api

same curl can be used as the sleep container - just switching to external IP:
`curl https://httpbin.tetrate.io/get --resolve httpbin.tetrate.io:443:104.196.31.107 -u alice:password -I -k -X GET`