### PR TITLE
fix aws cleanup and dns_provider extrapolation based on tsb fqdn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ tsb_mp:  ## Deploys MP
 		set -e; \
 		cloud=`jq -r '.tsb_mp.cloud' terraform.tfvars.json`; \
 		dns_provider=`jq -r '.dns_provider' terraform.tfvars.json`; \
-		[ "$$dns_provider" == "null" ] && dns_provider=`jq -r '.tsb.fqdn' terraform.tfvars.json | jq -Rr 'split(".")[1] | if . == "azure" then "azure" elif . == "gcp" then "gcp" else "aws" end'`; \
+		[ "$$dns_provider" == "null" ] && dns_provider=`jq -r '.tsb_fqdn' terraform.tfvars.json | cut -d"." -f2 | sed 's/sandbox/gcp/g'`; \
 		cd "tsb/mp"; \
 		terraform workspace select default; \
 		terraform init; \

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ tsb_mp:  ## Deploys MP
 		set -e; \
 		cloud=`jq -r '.tsb_mp.cloud' terraform.tfvars.json`; \
 		dns_provider=`jq -r '.dns_provider' terraform.tfvars.json`; \
-		[ "$$dns_provider" == "null" ] && dns_provider=`jq -r '.tsb_fqdn' terraform.tfvars.json | cut -d"." -f2 | sed 's/sandbox/gcp/g'`; \
+		[ "$$dns_provider" == "null" ] && dns_provider=`jq -r '.tsb.fqdn' terraform.tfvars.json | jq -Rr 'split(".")[1] | if . == "azure" then "azure" elif . == "gcp" then "gcp" else "aws" end'`; \
 		cd "tsb/mp"; \
 		terraform workspace select default; \
 		terraform init; \

--- a/modules/aws/base/aws_cleanup.sh.tmpl
+++ b/modules/aws/base/aws_cleanup.sh.tmpl
@@ -26,7 +26,7 @@ done
 sleep 60
 
 echo 'Destroying K8s ELB SGs...'
-for sg in $(aws ec2 --region $REGION describe-security-groups --filters "Name=vpc-id,Values=$VPC_ID" --query "SecurityGroups[*].GroupId" --output text); do 
+for sg in $(aws ec2 --region $REGION describe-security-groups --filters "Name=vpc-id,Values=$VPC_ID" --query "SecurityGroups[?GroupName!='default'].GroupId" --output text); do
     echo "Removing $sg..."
     aws ec2 delete-security-group --region $REGION --group-id $sg 
 done


### PR DESCRIPTION
1. The AWS cleanup script sometimes failed pre-maturely because it also tried to delete the default SG associated with the VPC, which is not allowed (per AWS design). Since we used `set -e`, the script would stop and potentially not delete the EKS related SG's, leading to failure of VPC cleanup.

2. The logic to extrapolate dns_provider based on TSB FQDN did not match in case AWS was used.