### PR TITLE
Avoid accidental total destruction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 # Environment configuration
 dry_run     ?= false
+interactive ?= true
 tfvars_json ?= terraform.tfvars.json
 tf_log			?= "ERROR"
 
@@ -70,13 +71,31 @@ destroy_external_dns_%:
 	@/bin/sh -c 'export DRY_RUN="${dry_run}" TF_LOG="${tf_log}" TFVARS_JSON="${tfvars_json}" && ./make/addon.sh destroy_external_dns_$*'
 
 .PHONY: destroy
-destroy: destroy_remote destroy_local ## Destroy environment and local terraform state, cache and output artifacts
+destroy: confirm_destroy  ## Destroy environment and local terraform state, cache and output artifacts
+
+.PHONY: confirm_destroy
+confirm_destroy:
+ifeq ($(interactive),false)
+	@echo "\033[1;31mDestroying without confirmation (interactive=false) \033[0m"
+	@$(MAKE) actual_destroy
+else
+	@echo -n "\033[1;31mDo you really want to destroy (y/n)? \033[0m"  # Bold red text
+	@read -p "" choice; \
+	if [ "$${choice}" = "y" ] || [ "$${choice}" = "Y" ] || [ "$${choice}" = "yes" ] || [ "$${choice}" = "YES" ]; then \
+		$(MAKE) actual_destroy; \
+	else \
+		echo "Destroy canceled."; \
+	fi
+endif
+
+.PHONY: actual_destroy
+actual_destroy: destroy_remote destroy_local
 
 .PHONY: destroy_remote
 destroy_remote:  ## Destroy environment
 	@echo "Destroy TSB Management Plane FQDN..."
 	@/bin/sh -c 'export DRY_RUN="${dry_run}" TF_LOG="${tf_log}" TFVARS_JSON="${tfvars_json}" && ./make/tsb.sh destroy_remote'
-	@$(MAKE) destroy_external_dns
+	# @$(MAKE) destroy_external_dns
 	@$(MAKE) destroy_infra
 
 .PHONY: destroy_local


### PR DESCRIPTION
This adds accidental destroy protection with a flag to override interaction for automated purposes.

```bash
boeboe@Boeboe-NUC-WORK:~/Git/tetrate/tetrate-service-bridge-sandbox (delete-confirm) $ make destroy
Do you really want to destroy (y/n)? 
Destroy canceled.

boeboe@Boeboe-NUC-WORK:~/Git/tetrate/tetrate-service-bridge-sandbox (delete-confirm) $ make destroy interactive=true
Do you really want to destroy (y/n)? 
Destroy canceled.

boeboe@Boeboe-NUC-WORK:~/Git/tetrate/tetrate-service-bridge-sandbox (delete-confirm) $ make destroy interactive=false dry_run=true
Destroying without confirmation (interactive=false) 
make[1]: Entering directory '/home/boeboe/Git/tetrate/tetrate-service-bridge-sandbox'
Destroy TSB Management Plane FQDN...
JSON structure of 'terraform.tfvars.json' is valid.
Going to destroy tsb management plane fqdn
jq: error: Could not open file outputs/terraform_outputs/terraform-tsb-mp.json: No such file or directory
Going to destroy tsb management plane fqdn on cloud 'azure'
pushd tsb/fqdn/azure > /dev/null
terraform workspace select default
...

```

![Screenshot from 2023-10-25 07-13-04](https://github.com/tetrateio/tetrate-service-bridge-sandbox/assets/415310/c83edf87-6a1c-45c6-9bc8-073aeee0ad40)

