### PR TITLE
Add VPC Native subnets in GCP

### DIFF
--- a/infra/aws/variables.tf
+++ b/infra/aws/variables.tf
@@ -15,7 +15,7 @@ variable "name_prefix" {
 variable "cidr" {
   type        = string
   description = "cidr"
-  default     = "172.20.0.0/16"
+  default     = "172.16.0.0/12"
 }
 
 variable "tsb_image_sync_username" {

--- a/infra/azure/variables.tf
+++ b/infra/azure/variables.tf
@@ -16,7 +16,7 @@ variable "name_prefix" {
 variable "cidr" {
   type        = string
   description = "cidr"
-  default     = "172.20.0.0/16"
+  default     = "172.16.0.0/12"
 }
 
 variable "tsb_image_sync_username" {

--- a/infra/gcp/variables.tf
+++ b/infra/gcp/variables.tf
@@ -16,7 +16,7 @@ variable "name_prefix" {
 variable "cidr" {
   type        = string
   description = "cidr"
-  default     = "172.20.0.0/16"
+  default     = "172.16.0.0/12"
 }
 
 variable "tsb_image_sync_username" {

--- a/modules/gcp/base/main.tf
+++ b/modules/gcp/base/main.tf
@@ -48,14 +48,24 @@ data "google_compute_zones" "available" {
 }
 
 resource "google_compute_subnetwork" "tsb" {
-  count = min(var.min_az_count, var.max_az_count)
+  count = 1
   name  = "${var.name_prefix}-subnet${data.google_compute_zones.available.names[count.index]}"
 
   project = var.project_id
   region  = var.region
   network = google_compute_network.tsb.self_link
 
-  ip_cidr_range = cidrsubnet(var.cidr, 4, count.index)
+  ip_cidr_range = cidrsubnet(var.cidr, 2, count.index)
+
+  secondary_ip_range {
+    range_name    = "pods"
+    ip_cidr_range = cidrsubnet(var.cidr, 2, count.index + 1)
+  }
+
+  secondary_ip_range {
+    range_name    = "services"
+    ip_cidr_range = cidrsubnet(var.cidr, 2, count.index + 2)
+  }
 }
 
 resource "google_compute_router_nat" "tsb" {

--- a/modules/gcp/k8s/main.tf
+++ b/modules/gcp/k8s/main.tf
@@ -14,6 +14,8 @@ resource "google_container_cluster" "tsb" {
   min_master_version = var.k8s_version
   network            = var.vpc_id
   subnetwork         = var.vpc_subnet
+  networking_mode    = "VPC_NATIVE"
+  datapath_provider  = "ADVANCED_DATAPATH"
 
   # We can't create a cluster with no node pool defined, but we want to only use
   # separately managed node pools. So we create the smallest possible default
@@ -22,8 +24,13 @@ resource "google_container_cluster" "tsb" {
   initial_node_count       = 1
 
   resource_labels = merge(var.tags, {
-    name        = "${var.cluster_name}_tsb_sandbox_blue"
+    name = "${var.cluster_name}_tsb_sandbox_blue"
   })
+
+  ip_allocation_policy {
+    cluster_secondary_range_name  = "pods"
+    services_secondary_range_name = "services"
+  }
 
   depends_on = [
     google_project_service.container
@@ -39,7 +46,7 @@ resource "google_container_node_pool" "primary_nodes" {
 
   node_config {
     preemptible  = var.preemptible_nodes
-    machine_type = "e2-standard-4"
+    machine_type = "n2-standard-8"
 
     # Google recommends custom service accounts that have cloud-platform scope and permissions granted via IAM Roles.
     service_account = data.google_compute_default_service_account.default.email

--- a/modules/gcp/k8s/main.tf
+++ b/modules/gcp/k8s/main.tf
@@ -46,7 +46,7 @@ resource "google_container_node_pool" "primary_nodes" {
 
   node_config {
     preemptible  = var.preemptible_nodes
-    machine_type = "n2-standard-8"
+    machine_type = "e2-standard-8"
 
     # Google recommends custom service accounts that have cloud-platform scope and permissions granted via IAM Roles.
     service_account = data.google_compute_default_service_account.default.email

--- a/modules/gcp/k8s/variables.tf
+++ b/modules/gcp/k8s/variables.tf
@@ -28,5 +28,5 @@ variable "output_path" {
 }
 
 variable "tags" {
-  type = map
+  type = map(any)
 }


### PR DESCRIPTION
More details: https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips

In order to do VPC peering and support a direct pod to pod communications VPC native clusters are required