### PR TITLE
ES upgrade to 8.10.4 + Moving back to built-in cert-manager with AUTO mode for control planes, leveraging built-in TSB capabilties to generate Istiod cacerts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ ifeq ($(interactive),false)
 	@echo "\033[1;31mDestroying without confirmation (interactive=false) \033[0m"
 	@$(MAKE) actual_destroy
 else
-	@echo -n "\033[1;31mDo you really want to destroy (y/n)? \033[0m"  # Bold red text
+	@echo "\033[1;31mDo you really want to destroy (y/n)? \033[0m"  # Bold red text
 	@read -p "" choice; \
 	if [ "$${choice}" = "y" ] || [ "$${choice}" = "Y" ] || [ "$${choice}" = "yes" ] || [ "$${choice}" = "YES" ]; then \
 		$(MAKE) actual_destroy; \

--- a/modules/addons/elastic/manifests/es.yaml
+++ b/modules/addons/elastic/manifests/es.yaml
@@ -5,7 +5,7 @@ metadata:
   name: tsb
   namespace: elastic-system
 spec:
-  version: 7.13.2
+  version: 8.10.4
   http:
     service:
       spec:
@@ -19,6 +19,7 @@ spec:
         - name: sysctl
           securityContext:
             privileged: true
+            runAsUser: 0
           command: ['sh', '-c', 'sysctl -w vm.max_map_count=262144']
     volumeClaimTemplates:
     - metadata:
@@ -36,7 +37,7 @@ metadata:
   name: tsb
   namespace: elastic-system
 spec:
-  version: 7.13.2
+  version: 8.10.4
   http:
     service:
       spec:

--- a/modules/tsb/cp/main.tf
+++ b/modules/tsb/cp/main.tf
@@ -77,18 +77,18 @@ resource "helm_release" "controlplane" {
   timeout             = 900
 
   values = [templatefile("${path.module}/manifests/tsb/controlplane-values.yaml.tmpl", {
-    registry                        = var.registry
-    tsb_version                     = var.tsb_version
-    tsb_fqdn                        = var.tsb_fqdn
-    cluster_name                    = var.cluster_name
-    serviceaccount_clusterfqn       = "organizations/${var.tsb_org}/clusters/${var.cluster_name}"
-    serviceaccount_jwk              = data.local_file.service_account.content
-    es_host                         = var.es_host
-    es_username                     = var.es_username
-    es_password                     = var.es_password
-    ratelimit_enabled               = var.ratelimit_enabled
-    ratelimit_namespace             = var.ratelimit_namespace
-    identity_propagation_enabled    = var.identity_propagation_enabled
+    registry                     = var.registry
+    tsb_version                  = var.tsb_version
+    tsb_fqdn                     = var.tsb_fqdn
+    cluster_name                 = var.cluster_name
+    serviceaccount_clusterfqn    = "organizations/${var.tsb_org}/clusters/${var.cluster_name}"
+    serviceaccount_jwk           = data.local_file.service_account.content
+    es_host                      = var.es_host
+    es_username                  = var.es_username
+    es_password                  = var.es_password
+    ratelimit_enabled            = var.ratelimit_enabled
+    ratelimit_namespace          = var.ratelimit_namespace
+    identity_propagation_enabled = var.identity_propagation_enabled
   })]
 
   set {
@@ -117,26 +117,6 @@ resource "kubernetes_secret" "redis_password" {
   data = {
     REDIS_AUTH = var.redis_password
   }
-}
-
-resource "kubernetes_secret_v1" "cacerts" {
-  metadata {
-    name      = "cacerts"
-    namespace = "istio-system"
-    annotations = {
-      clustername = var.cluster_name
-    }
-  }
-
-  data = {
-    "ca-cert.pem"    = var.istiod_cacerts_tls_crt
-    "ca-key.pem"     = var.istiod_cacerts_tls_key
-    "root-cert.pem"  = var.tsb_cacert
-    "cert-chain.pem" = var.istiod_cacerts_tls_crt
-  }
-
-  type       = "kubernetes.io/generic"
-  depends_on = [helm_release.controlplane]
 }
 
 resource "kubernetes_secret_v1" "cr_pull_secret" {

--- a/modules/tsb/cp/manifests/tsb/controlplane-values.yaml.tmpl
+++ b/modules/tsb/cp/manifests/tsb/controlplane-values.yaml.tmpl
@@ -79,7 +79,7 @@ spec:
       reconcileInterval: 600s
     internalCertProvider:
       certManager:
-        managed: EXTERNAL
+        managed: AUTO
     oap:
       streamingLogEnabled: true
     %{ if ratelimit_enabled }

--- a/modules/tsb/cp/manifests/tsb/controlplane-values.yaml.tmpl
+++ b/modules/tsb/cp/manifests/tsb/controlplane-values.yaml.tmpl
@@ -30,6 +30,7 @@ spec:
       mountInternalWasmExtensions: true
     xcp:
       centralAuthMode: JWT
+      centralProvidedCaCert: true 
       configProtection: {}
       enableHttpMeshInternalIdentityPropagation: ${identity_propagation_enabled}
       isolationBoundaries:

--- a/modules/tsb/cp/variables.tf
+++ b/modules/tsb/cp/variables.tf
@@ -58,12 +58,6 @@ variable "tsb_password" {
 variable "tsb_cacert" {
 }
 
-variable "istiod_cacerts_tls_crt" {
-}
-
-variable "istiod_cacerts_tls_key" {
-}
-
 variable "tsb_image_sync_username" {
 }
 

--- a/modules/tsb/mp/main.tf
+++ b/modules/tsb/mp/main.tf
@@ -60,14 +60,6 @@ data "kubernetes_secret" "tsb_server_cert" {
   depends_on = [time_sleep.warmup_90_seconds]
 }
 
-data "kubernetes_secret" "istiod_cacerts" {
-  metadata {
-    name      = "istiod-cacerts"
-    namespace = "cert-manager"
-  }
-  depends_on = [time_sleep.warmup_90_seconds]
-}
-
 resource "random_password" "tsb" {
   length = 16
 }

--- a/modules/tsb/mp/manifests/tsb/managementplane-values.yaml.tmpl
+++ b/modules/tsb/mp/manifests/tsb/managementplane-values.yaml.tmpl
@@ -18,6 +18,9 @@ secrets:
     username: ${db_username}
     password: ${db_password}
 spec:
+  certIssuer:
+    selfSigned: {}
+    clusterIntermediateCAs: {}
   hub: "${registry}"
   organization: "${tsb_org}"
   telemetryStore:

--- a/modules/tsb/mp/outputs.tf
+++ b/modules/tsb/mp/outputs.tf
@@ -11,14 +11,6 @@ output "tsb_cacert" {
   value = data.kubernetes_secret.selfsigned_ca.data["tls.crt"]
 }
 
-output "istiod_cacerts_tls_crt" {
-  value = data.kubernetes_secret.istiod_cacerts.data["tls.crt"]
-}
-
-output "istiod_cacerts_tls_key" {
-  value = data.kubernetes_secret.istiod_cacerts.data["tls.key"]
-}
-
 output "password" {
   value     = coalesce(var.tsb_password, random_password.tsb.result)
   sensitive = true

--- a/tsb/cp/main.tf
+++ b/tsb/cp/main.tf
@@ -20,15 +20,6 @@ data "terraform_remote_state" "tsb_mp" {
   }
 }
 
-module "cert-manager" {
-  source                     = "../../modules/addons/cert-manager"
-  cluster_name               = data.terraform_remote_state.infra.outputs.cluster_name
-  k8s_host                   = data.terraform_remote_state.infra.outputs.host
-  k8s_cluster_ca_certificate = data.terraform_remote_state.infra.outputs.cluster_ca_certificate
-  k8s_client_token           = data.terraform_remote_state.k8s_auth.outputs.token
-  cert-manager_enabled       = tonumber(var.cluster_id) == tonumber(var.tsb_mp["cluster_id"]) && var.cloud == var.tsb_mp["cloud"] ? false : var.cert-manager_enabled
-}
-
 module "ratelimit" {
   source                     = "../../modules/addons/ratelimit"
   cluster_name               = data.terraform_remote_state.infra.outputs.cluster_name
@@ -39,44 +30,42 @@ module "ratelimit" {
 }
 
 module "tsb_cp" {
-  source                          = "../../modules/tsb/cp"
-  cloud                           = var.cloud
-  locality_region                 = data.terraform_remote_state.infra.outputs.locality_region
-  cluster_id                      = var.cluster_id
-  name_prefix                     = "${var.name_prefix}-${var.cluster_id}"
-  tsb_version                     = var.tsb_version
-  tsb_helm_repository             = var.tsb_helm_repository
-  tsb_helm_repository_username    = var.tsb_helm_repository_username
-  tsb_helm_repository_password    = var.tsb_helm_repository_password
-  tsb_helm_version                = coalesce(var.tsb_helm_version, var.tsb_version)
-  tsb_mp_host                     = data.terraform_remote_state.tsb_mp.outputs.fqdn
-  tier1_cluster                   = tonumber(var.cluster_id) == tonumber(var.tsb_mp["cluster_id"]) && var.cloud == var.tsb_mp["cloud"] ? var.mp_as_tier1_cluster : false
-  tsb_fqdn                        = var.tsb_fqdn
-  tsb_org                         = var.tsb_org
-  tsb_username                    = var.tsb_username
-  tsb_password                    = data.terraform_remote_state.tsb_mp.outputs.tsb_password
-  tsb_cacert                      = data.terraform_remote_state.tsb_mp.outputs.tsb_cacert
-  ratelimit_enabled               = var.ratelimit_enabled
-  ratelimit_namespace             = module.ratelimit.namespace
-  redis_password                  = module.ratelimit.redis_password
-  identity_propagation_enabled    = var.identity_propagation_enabled
-  istiod_cacerts_tls_crt          = data.terraform_remote_state.tsb_mp.outputs.istiod_cacerts_tls_crt
-  istiod_cacerts_tls_key          = data.terraform_remote_state.tsb_mp.outputs.istiod_cacerts_tls_key
-  tsb_image_sync_username         = var.tsb_image_sync_username
-  tsb_image_sync_apikey           = var.tsb_image_sync_apikey
-  output_path                     = var.output_path
-  es_host                         = coalesce(data.terraform_remote_state.tsb_mp.outputs.es_ip, data.terraform_remote_state.tsb_mp.outputs.es_hostname)
-  es_username                     = data.terraform_remote_state.tsb_mp.outputs.es_username
-  es_password                     = data.terraform_remote_state.tsb_mp.outputs.es_password
-  es_cacert                       = data.terraform_remote_state.tsb_mp.outputs.es_cacert
-  jumpbox_host                    = data.terraform_remote_state.infra.outputs.public_ip
-  jumpbox_username                = var.jumpbox_username
-  jumpbox_pkey                    = data.terraform_remote_state.infra.outputs.pkey
-  registry                        = data.terraform_remote_state.infra.outputs.registry
-  registry_username               = data.terraform_remote_state.infra.outputs.registry_username
-  registry_password               = data.terraform_remote_state.infra.outputs.registry_password
-  cluster_name                    = data.terraform_remote_state.infra.outputs.cluster_name
-  k8s_host                        = data.terraform_remote_state.infra.outputs.host
-  k8s_cluster_ca_certificate      = data.terraform_remote_state.infra.outputs.cluster_ca_certificate
-  k8s_client_token                = data.terraform_remote_state.k8s_auth.outputs.token
+  source                       = "../../modules/tsb/cp"
+  cloud                        = var.cloud
+  locality_region              = data.terraform_remote_state.infra.outputs.locality_region
+  cluster_id                   = var.cluster_id
+  name_prefix                  = "${var.name_prefix}-${var.cluster_id}"
+  tsb_version                  = var.tsb_version
+  tsb_helm_repository          = var.tsb_helm_repository
+  tsb_helm_repository_username = var.tsb_helm_repository_username
+  tsb_helm_repository_password = var.tsb_helm_repository_password
+  tsb_helm_version             = coalesce(var.tsb_helm_version, var.tsb_version)
+  tsb_mp_host                  = data.terraform_remote_state.tsb_mp.outputs.fqdn
+  tier1_cluster                = tonumber(var.cluster_id) == tonumber(var.tsb_mp["cluster_id"]) && var.cloud == var.tsb_mp["cloud"] ? var.mp_as_tier1_cluster : false
+  tsb_fqdn                     = var.tsb_fqdn
+  tsb_org                      = var.tsb_org
+  tsb_username                 = var.tsb_username
+  tsb_password                 = data.terraform_remote_state.tsb_mp.outputs.tsb_password
+  tsb_cacert                   = data.terraform_remote_state.tsb_mp.outputs.tsb_cacert
+  ratelimit_enabled            = var.ratelimit_enabled
+  ratelimit_namespace          = module.ratelimit.namespace
+  redis_password               = module.ratelimit.redis_password
+  identity_propagation_enabled = var.identity_propagation_enabled
+  tsb_image_sync_username      = var.tsb_image_sync_username
+  tsb_image_sync_apikey        = var.tsb_image_sync_apikey
+  output_path                  = var.output_path
+  es_host                      = coalesce(data.terraform_remote_state.tsb_mp.outputs.es_ip, data.terraform_remote_state.tsb_mp.outputs.es_hostname)
+  es_username                  = data.terraform_remote_state.tsb_mp.outputs.es_username
+  es_password                  = data.terraform_remote_state.tsb_mp.outputs.es_password
+  es_cacert                    = data.terraform_remote_state.tsb_mp.outputs.es_cacert
+  jumpbox_host                 = data.terraform_remote_state.infra.outputs.public_ip
+  jumpbox_username             = var.jumpbox_username
+  jumpbox_pkey                 = data.terraform_remote_state.infra.outputs.pkey
+  registry                     = data.terraform_remote_state.infra.outputs.registry
+  registry_username            = data.terraform_remote_state.infra.outputs.registry_username
+  registry_password            = data.terraform_remote_state.infra.outputs.registry_password
+  cluster_name                 = data.terraform_remote_state.infra.outputs.cluster_name
+  k8s_host                     = data.terraform_remote_state.infra.outputs.host
+  k8s_cluster_ca_certificate   = data.terraform_remote_state.infra.outputs.cluster_ca_certificate
+  k8s_client_token             = data.terraform_remote_state.k8s_auth.outputs.token
 }

--- a/tsb/cp/variables.tf
+++ b/tsb/cp/variables.tf
@@ -129,10 +129,6 @@ variable "output_path" {
   default = "../../outputs"
 }
 
-variable "cert-manager_enabled" {
-  default = true
-}
-
 variable "ratelimit_enabled" {
   default = true
 }

--- a/tsb/mp/outputs.tf
+++ b/tsb/mp/outputs.tf
@@ -15,16 +15,6 @@ output "tsb_cacert" {
   sensitive = true
 }
 
-output "istiod_cacerts_tls_crt" {
-  value     = module.tsb_mp.istiod_cacerts_tls_crt
-  sensitive = true
-}
-
-output "istiod_cacerts_tls_key" {
-  value     = module.tsb_mp.istiod_cacerts_tls_key
-  sensitive = true
-}
-
 output "es_ip" {
   value = module.es.es_ip
 }


### PR DESCRIPTION
1. Upgrade ES to 8.10.4
2. Setting cert-manager to AUTO for control planes
3. Leveraging TSB to generate and distribute Istiod cacerts