### PR TITLE
Prevent kubernetes auth from failing due to long running terraform apply as k8s auth token expires in 15 minutes (AWS caveat).

### DIFF
--- a/make/helpers.sh
+++ b/make/helpers.sh
@@ -15,6 +15,7 @@ function run() {
   if ${DRY_RUN:-false}; then
     printf "%s\n" "$*"
   else
+    print_command "$*"
     eval "$@"
   fi
 }

--- a/make/tsb.sh
+++ b/make/tsb.sh
@@ -49,6 +49,8 @@ function deploy_mp() {
   run "terraform init"
   run "terraform apply ${TERRAFORM_APPLY_ARGS} -target=module.cert-manager -target=module.es -target=data.terraform_remote_state.infra -var-file=../../${TFVARS_JSON} -var=cluster='${cluster}'"
   run "terraform apply ${TERRAFORM_APPLY_ARGS} -target=module.tsb_mp.kubectl_manifest.manifests_certs -target=data.terraform_remote_state.infra -var-file=../../${TFVARS_JSON} -var=cluster='${cluster}'"
+  # Prevent kubernetes auth from failing due to long running terraform apply as k8s auth token expires in 15 minutes (AWS caveat).
+  source "${BASE_DIR}/k8s_auth.sh" k8s_auth_${cloud}
   run "terraform apply ${TERRAFORM_APPLY_ARGS} -var-file=../../${TFVARS_JSON} -var=cluster='${cluster}'"
   run "terraform output ${TERRAFORM_OUTPUT_ARGS} | jq . > ../../outputs/terraform_outputs/terraform-tsb-mp.json"
   run "terraform workspace select default"

--- a/make/tsb.sh
+++ b/make/tsb.sh
@@ -48,10 +48,13 @@ function deploy_mp() {
   run "terraform workspace select ${workspace}"
   run "terraform init"
   run "terraform apply ${TERRAFORM_APPLY_ARGS} -target=module.cert-manager -target=module.es -target=data.terraform_remote_state.infra -var-file=../../${TFVARS_JSON} -var=cluster='${cluster}'"
-  run "terraform apply ${TERRAFORM_APPLY_ARGS} -target=module.tsb_mp.kubectl_manifest.manifests_certs -target=data.terraform_remote_state.infra -var-file=../../${TFVARS_JSON} -var=cluster='${cluster}'"
   # Prevent kubernetes auth from failing due to long running terraform apply as k8s auth token expires in 15 minutes (AWS caveat).
+  run "popd > /dev/null"
   source "${BASE_DIR}/k8s_auth.sh" k8s_auth_${cloud}
-  run "terraform apply ${TERRAFORM_APPLY_ARGS} -var-file=../../${TFVARS_JSON} -var=cluster='${cluster}'"
+  run "pushd tsb/mp > /dev/null"
+  run "terraform workspace select ${workspace}"
+  run "terraform apply ${TERRAFORM_APPLY_ARGS} -target=module.tsb_mp.kubectl_manifest.manifests_certs -target=data.terraform_remote_state.infra -var-file=../../${TFVARS_JSON} -var=cluster='${cluster}'" 
+  run "terraform apply ${TERRAFORM_APPLY_ARGS} -target=data.terraform_remote_state.infra -var-file=../../${TFVARS_JSON} -var=cluster='${cluster}'"
   run "terraform output ${TERRAFORM_OUTPUT_ARGS} | jq . > ../../outputs/terraform_outputs/terraform-tsb-mp.json"
   run "terraform workspace select default"
   run "popd > /dev/null"

--- a/make/tsb.sh
+++ b/make/tsb.sh
@@ -53,8 +53,8 @@ function deploy_mp() {
   source "${BASE_DIR}/k8s_auth.sh" k8s_auth_${cloud}
   run "pushd tsb/mp > /dev/null"
   run "terraform workspace select ${workspace}"
-  run "terraform apply ${TERRAFORM_APPLY_ARGS} -target=module.tsb_mp.kubectl_manifest.manifests_certs -target=data.terraform_remote_state.infra -var-file=../../${TFVARS_JSON} -var=cluster='${cluster}'" 
-  run "terraform apply ${TERRAFORM_APPLY_ARGS} -target=data.terraform_remote_state.infra -var-file=../../${TFVARS_JSON} -var=cluster='${cluster}'"
+  run "terraform apply ${TERRAFORM_APPLY_ARGS} -target=module.tsb_mp.kubectl_manifest.manifests_certs -target=data.terraform_remote_state.infra -var-file=../../${TFVARS_JSON} -var=cluster='${cluster}'"
+  run "terraform apply ${TERRAFORM_APPLY_ARGS} -var-file=../../${TFVARS_JSON} -var=cluster='${cluster}'"
   run "terraform output ${TERRAFORM_OUTPUT_ARGS} | jq . > ../../outputs/terraform_outputs/terraform-tsb-mp.json"
   run "terraform workspace select default"
   run "popd > /dev/null"

--- a/modules/addons/elastic/main.tf
+++ b/modules/addons/elastic/main.tf
@@ -13,6 +13,12 @@ provider "kubectl" {
   load_config_file       = false
 }
 
+provider "kubernetes" {
+  host                   = var.k8s_host
+  cluster_ca_certificate = base64decode(var.k8s_cluster_ca_certificate)
+  token                  = var.k8s_client_token
+}
+
 resource "helm_release" "elasticsearch" {
   name             = "elasticsearch"
   repository       = "https://helm.elastic.co"


### PR DESCRIPTION
Prevent kubernetes auth from failing due to long running terraform apply as k8s auth token expires in 15 minutes (AWS caveat).

address Elastic Search timeouts...

```
│ Warning: Applied changes may be incomplete
│
│ The plan was created with the -target option in effect, so some changes requested in the configuration may
│ have been ignored and the output values may not be fully updated. Run the following command to verify that no
│ other changes are pending:
│     terraform plan
│
│ Note that the -target option is not suitable for routine use, and is provided only for exceptional situations
│ such as recovering from errors or mistakes, or when Terraform specifically suggests to use it as part of an
│ error message.
╵
╷
│ Error: Unauthorized
│
│   with module.es.data.kubernetes_secret.es_password,
│   on ../../modules/addons/elastic/main.tf line 52, in data "kubernetes_secret" "es_password":
│   52: data "kubernetes_secret" "es_password" {
│
╵
╷
│ Error: Unauthorized
│
│   with module.es.data.kubernetes_secret.es_cacert,
│   on ../../modules/addons/elastic/main.tf line 60, in data "kubernetes_secret" "es_cacert":
│   60: data "kubernetes_secret" "es_cacert" {
│
╵
╷
│ Error: Unauthorized
│
│   with module.es.data.kubernetes_service.es,
│   on ../../modules/addons/elastic/main.tf line 69, in data "kubernetes_service" "es":
│   69: data "kubernetes_service" "es" {
│
╵
make: *** [tsb_mp] Error 1
```