### PR TITLE
Identity propagation is enabled by default from 1.8

### DIFF
--- a/modules/tsb/cp/main.tf
+++ b/modules/tsb/cp/main.tf
@@ -87,7 +87,6 @@ resource "helm_release" "controlplane" {
     es_password                  = var.es_password
     ratelimit_enabled            = var.ratelimit_enabled
     ratelimit_namespace          = var.ratelimit_namespace
-    identity_propagation_enabled = var.identity_propagation_enabled
   })]
 
   set {
@@ -116,28 +115,4 @@ resource "kubernetes_secret" "redis_password" {
   data = {
     REDIS_AUTH = var.redis_password
   }
-}
-
-resource "kubernetes_secret_v1" "cr_pull_secret" {
-  metadata {
-    name      = "cr-pull-secret"
-    namespace = "istio-system"
-    annotations = {
-      clustername = var.cluster_name
-    }
-  }
-
-  data = {
-    ".dockerconfigjson" = jsonencode({
-      auths = {
-        "${var.registry}" = {
-          "username" = var.registry_username
-          "password" = var.registry_password
-        }
-      }
-    })
-  }
-
-  type       = "kubernetes.io/dockerconfigjson"
-  depends_on = [helm_release.controlplane]
 }

--- a/modules/tsb/cp/manifests/tsb/controlplane-values.yaml.tmpl
+++ b/modules/tsb/cp/manifests/tsb/controlplane-values.yaml.tmpl
@@ -9,10 +9,6 @@ secrets:
     JWK: '${serviceaccount_jwk}'
 spec:
   hub: ${registry}
-  %{ if identity_propagation_enabled }
-  imagePullSecrets:
-  - name: cr-pull-secret
-  %{ endif }
   telemetryStore:
     elastic:
       host: ${es_host}
@@ -26,13 +22,10 @@ spec:
     clusterName: ${cluster_name}
     selfSigned: true
   components:
-    istio:
-      mountInternalWasmExtensions: true
     xcp:
       centralAuthMode: JWT
       centralProvidedCaCert: true
       configProtection: {}
-      enableHttpMeshInternalIdentityPropagation: ${identity_propagation_enabled}
       isolationBoundaries:
       - name: global
         revisions:

--- a/modules/tsb/cp/variables.tf
+++ b/modules/tsb/cp/variables.tf
@@ -102,6 +102,3 @@ variable "redis_password" {
 
 variable "output_path" {
 }
-
-variable "identity_propagation_enabled" {
-}

--- a/tsb/cp/main.tf
+++ b/tsb/cp/main.tf
@@ -49,7 +49,6 @@ module "tsb_cp" {
   ratelimit_enabled            = var.ratelimit_enabled
   ratelimit_namespace          = module.ratelimit.namespace
   redis_password               = module.ratelimit.redis_password
-  identity_propagation_enabled = var.identity_propagation_enabled
   tsb_image_sync_username      = local.tetrate.image_sync_username
   tsb_image_sync_apikey        = local.tetrate.image_sync_apikey
   output_path                  = var.output_path

--- a/tsb/cp/variables.tf
+++ b/tsb/cp/variables.tf
@@ -98,8 +98,3 @@ variable "ratelimit_enabled" {
   description = "enable ratelimit"
   default     = true
 }
-
-variable "identity_propagation_enabled" {
-  description = "enable identity propagation"
-  default     = false
-}


### PR DESCRIPTION
Creating the branch to test with the latest `1.8.0` RC where `enableHttpMeshInternalIdentityPropagation` and `mountInternalWasmExtensions` is enabled by default.