### PR TITLE
have CPs pre-provision CM

### DIFF
--- a/modules/tsb/cp/main.tf
+++ b/modules/tsb/cp/main.tf
@@ -19,6 +19,15 @@ provider "kubernetes" {
   token                  = var.k8s_client_token
 }
 
+resource "kubernetes_namespace" "istio-system" {
+  metadata {
+    name = "istio-system"
+  }
+  lifecycle {
+    ignore_changes = [metadata]
+  }
+}
+
 resource "null_resource" "jumpbox_tctl" {
   connection {
     host        = var.jumpbox_host
@@ -71,7 +80,6 @@ resource "helm_release" "controlplane" {
   repository_password = var.tsb_helm_repository_password
   chart               = "controlplane"
   version             = var.tsb_helm_version
-  create_namespace    = true
   namespace           = "istio-system"
   timeout             = 900
 
@@ -102,6 +110,7 @@ resource "helm_release" "controlplane" {
     name  = "secrets.elasticsearch.cacert"
     value = var.es_cacert
   }
+  depends_on = [ kubernetes_namespace.istio-system ]
 }
 
 resource "kubernetes_secret" "redis_password" {

--- a/tsb/cp/main.tf
+++ b/tsb/cp/main.tf
@@ -20,6 +20,14 @@ data "terraform_remote_state" "tsb_mp" {
   }
 }
 
+module "cert-manager" {
+  source                     = "../../modules/addons/cert-manager"
+  cluster_name               = data.terraform_remote_state.infra.outputs.cluster_name
+  k8s_host                   = data.terraform_remote_state.infra.outputs.host
+  k8s_cluster_ca_certificate = data.terraform_remote_state.infra.outputs.cluster_ca_certificate
+  k8s_client_token           = data.terraform_remote_state.k8s_auth.outputs.token
+  cert-manager_enabled       = local.cluster.tetrate.management_plane ? false : var.cert-manager_enabled
+}
 module "ratelimit" {
   source                     = "../../modules/addons/ratelimit"
   cluster_name               = data.terraform_remote_state.infra.outputs.cluster_name


### PR DESCRIPTION
this will set us up for any addons to assume CM is pre-existing.  ie: vm onboarding needs a cert, so want to have that prepared before hand.