### PR TITLE
Moving to a single AZ kubernetes clusters, downsizing clusters and jumpboxes

### DIFF
--- a/infra/aws/variables.tf
+++ b/infra/aws/variables.tf
@@ -105,7 +105,7 @@ variable "cidr" {
 
 variable "jumpbox_machine_type" {
   type    = string
-  default = "t2.medium"
+  default = "t3.small"
 }
 
 variable "jumpbox_username" {

--- a/infra/aws/variables.tf
+++ b/infra/aws/variables.tf
@@ -21,8 +21,8 @@ locals {
       control_plane    = false
       management_plane = false
     }
-    version       = "1.27"
-    instance_type = "m7i.xlarge"
+    version       = "1.28"
+    instance_type = "m7i.large"
   }
   cluster = {
     cloud  = var.cluster.cloud

--- a/infra/azure/variables.tf
+++ b/infra/azure/variables.tf
@@ -21,8 +21,8 @@ locals {
       control_plane    = false
       management_plane = false
     }
-    version       = "1.28"
-    instance_type = "Standard_D4as_v5"
+    version       = "1.29"
+    instance_type = "Standard_D2as_v5"
   }
   cluster = {
     cloud  = var.cluster.cloud

--- a/infra/gcp/variables.tf
+++ b/infra/gcp/variables.tf
@@ -120,7 +120,7 @@ variable "gcp_org_id" {
 
 variable "jumpbox_machine_type" {
   type    = string
-  default = "n1-standard-2"
+  default = "n1-standard-1"
 }
 
 variable "jumpbox_username" {

--- a/infra/gcp/variables.tf
+++ b/infra/gcp/variables.tf
@@ -22,7 +22,7 @@ locals {
       management_plane = false
     }
     version       = "1.27"
-    instance_type = "e2-standard-4"
+    instance_type = "e2-standard-2"
   }
   cluster = {
     cloud  = var.cluster.cloud

--- a/infra/gcp/variables.tf
+++ b/infra/gcp/variables.tf
@@ -21,8 +21,8 @@ locals {
       control_plane    = false
       management_plane = false
     }
-    version       = "1.27"
-    instance_type = "e2-standard-2"
+    version       = "1.28"
+    instance_type = "e2-standard-4"
   }
   cluster = {
     cloud  = var.cluster.cloud

--- a/modules/aws/base/variables.tf
+++ b/modules/aws/base/variables.tf
@@ -10,7 +10,7 @@ variable "cidr" {
 
 variable "min_az_count" {
   type    = string
-  default = 2
+  default = 1
 }
 
 variable "max_az_count" {

--- a/modules/aws/base/variables.tf
+++ b/modules/aws/base/variables.tf
@@ -10,7 +10,7 @@ variable "cidr" {
 
 variable "min_az_count" {
   type    = string
-  default = 1
+  default = 2
 }
 
 variable "max_az_count" {

--- a/modules/aws/k8s/main.tf
+++ b/modules/aws/k8s/main.tf
@@ -157,6 +157,7 @@ module "eks-cluster-autoscaler" {
   cluster_name                     = var.cluster_name
   cluster_identity_oidc_issuer     = module.eks.cluster_oidc_issuer_url
   cluster_identity_oidc_issuer_arn = module.eks.oidc_provider_arn
+  helm_chart_name                  = var.cluster_name
 }
 
 resource "local_file" "gen_kubeconfig_sh" {

--- a/modules/aws/k8s/main.tf
+++ b/modules/aws/k8s/main.tf
@@ -1,7 +1,6 @@
 data "aws_availability_zones" "available" {}
 module "eks" {
-  source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.0"
+  source = "terraform-aws-modules/eks/aws"
 
   cluster_name                    = var.cluster_name
   cluster_version                 = var.k8s_version
@@ -49,7 +48,7 @@ module "eks" {
   eks_managed_node_groups = {
     tsb_sandbox_blue = {
       min_size     = 2
-      max_size     = 5
+      max_size     = 7
       desired_size = 2
     }
   }
@@ -146,6 +145,17 @@ module "load_balancer_controller" {
   cluster_identity_oidc_issuer_arn = module.eks.oidc_provider_arn
   cluster_name                     = var.cluster_name
   settings                         = var.lb_controller_settings
+}
+
+module "eks-cluster-autoscaler" {
+  source            = "lablabs/eks-cluster-autoscaler/aws"
+  enabled           = true
+  argo_enabled      = false
+  argo_helm_enabled = false
+
+  cluster_name                     = var.cluster_name
+  cluster_identity_oidc_issuer     = module.eks.cluster_oidc_issuer_url
+  cluster_identity_oidc_issuer_arn = module.eks.oidc_provider_arn
 }
 
 resource "local_file" "gen_kubeconfig_sh" {

--- a/modules/aws/k8s/main.tf
+++ b/modules/aws/k8s/main.tf
@@ -158,6 +158,7 @@ module "eks-cluster-autoscaler" {
   cluster_identity_oidc_issuer     = module.eks.cluster_oidc_issuer_url
   cluster_identity_oidc_issuer_arn = module.eks.oidc_provider_arn
   helm_release_name                = var.cluster_name
+  irsa_role_name_prefix            = var.cluster_name
 }
 
 resource "local_file" "gen_kubeconfig_sh" {

--- a/modules/aws/k8s/main.tf
+++ b/modules/aws/k8s/main.tf
@@ -1,6 +1,7 @@
 data "aws_availability_zones" "available" {}
 module "eks" {
-  source = "terraform-aws-modules/eks/aws"
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 19.0"
 
   cluster_name                    = var.cluster_name
   cluster_version                 = var.k8s_version

--- a/modules/aws/k8s/main.tf
+++ b/modules/aws/k8s/main.tf
@@ -157,7 +157,7 @@ module "eks-cluster-autoscaler" {
   cluster_name                     = var.cluster_name
   cluster_identity_oidc_issuer     = module.eks.cluster_oidc_issuer_url
   cluster_identity_oidc_issuer_arn = module.eks.oidc_provider_arn
-  helm_chart_name                  = var.cluster_name
+  helm_release_name                = var.cluster_name
 }
 
 resource "local_file" "gen_kubeconfig_sh" {

--- a/modules/azure/k8s/main.tf
+++ b/modules/azure/k8s/main.tf
@@ -17,6 +17,7 @@ resource "azurerm_kubernetes_cluster" "k8s" {
 
   default_node_pool {
     name                = replace("${substr(var.cluster_name, 0, min(length("${var.cluster_name}"), 6))}", "-", "")
+    zones               = [1]
     vnet_subnet_id      = var.vnet_subnet
     enable_auto_scaling = true
     min_count           = 2
@@ -27,7 +28,7 @@ resource "azurerm_kubernetes_cluster" "k8s" {
     upgrade_settings {
       max_surge = "10%"
     }
-    availability_zones = ["1"]
+
   }
 
   identity {

--- a/modules/azure/k8s/main.tf
+++ b/modules/azure/k8s/main.tf
@@ -27,6 +27,7 @@ resource "azurerm_kubernetes_cluster" "k8s" {
     upgrade_settings {
       max_surge = "10%"
     }
+    availability_zones = ["1"]
   }
 
   identity {

--- a/modules/azure/k8s/main.tf
+++ b/modules/azure/k8s/main.tf
@@ -21,7 +21,7 @@ resource "azurerm_kubernetes_cluster" "k8s" {
     vnet_subnet_id      = var.vnet_subnet
     enable_auto_scaling = true
     min_count           = 2
-    max_count           = 5
+    max_count           = 7
     vm_size             = var.instance_type
     type                = "VirtualMachineScaleSets"
     os_disk_size_gb     = 50

--- a/modules/gcp/base/main.tf
+++ b/modules/gcp/base/main.tf
@@ -48,7 +48,7 @@ data "google_compute_zones" "available" {
 }
 
 resource "google_compute_subnetwork" "tsb" {
-  count = 1
+  count = var.min_az_count
   name  = "${var.name_prefix}-subnet${data.google_compute_zones.available.names[count.index]}"
 
   project = var.project_id

--- a/modules/gcp/base/variables.tf
+++ b/modules/gcp/base/variables.tf
@@ -19,7 +19,7 @@ variable "cidr" {
 
 variable "min_az_count" {
   type    = number
-  default = 2
+  default = 1
 }
 
 variable "max_az_count" {

--- a/modules/gcp/k8s/main.tf
+++ b/modules/gcp/k8s/main.tf
@@ -5,9 +5,6 @@ data "google_compute_default_service_account" "default" {
 data "google_compute_zones" "available" {
   project = var.project_id
   region  = var.region
-  depends_on = [
-    time_sleep.wait_60_seconds
-  ]
 }
 
 resource "google_project_service" "container" {
@@ -48,7 +45,7 @@ resource "google_container_cluster" "tsb" {
 resource "google_container_node_pool" "primary_nodes" {
   name       = "${var.cluster_name}-pool"
   project    = var.project_id
-  location   = var.region
+  location   = data.google_compute_zones.available.names[0]
   cluster    = google_container_cluster.tsb.name
   node_count = 1
 
@@ -77,7 +74,7 @@ module "gke_auth" {
 
   project_id           = var.project_id
   cluster_name         = google_container_cluster.tsb.name
-  location             = var.region
+  location             = data.google_compute_zones.available.names[0]
   use_private_endpoint = false
   depends_on = [
     google_container_cluster.tsb

--- a/modules/gcp/k8s/main.tf
+++ b/modules/gcp/k8s/main.tf
@@ -47,11 +47,11 @@ resource "google_container_node_pool" "primary_nodes" {
   project    = var.project_id
   location   = data.google_compute_zones.available.names[0]
   cluster    = google_container_cluster.tsb.name
-  node_count = 1
+  node_count = 2
 
   autoscaling {
     min_node_count = 2
-    max_node_count = 5
+    max_node_count = 7
   }
 
   node_config {

--- a/modules/gcp/k8s/main.tf
+++ b/modules/gcp/k8s/main.tf
@@ -2,6 +2,14 @@ data "google_compute_default_service_account" "default" {
   project = var.project_id
 }
 
+data "google_compute_zones" "available" {
+  project = var.project_id
+  region  = var.region
+  depends_on = [
+    time_sleep.wait_60_seconds
+  ]
+}
+
 resource "google_project_service" "container" {
   project = var.project_id
   service = "container.googleapis.com"
@@ -10,7 +18,7 @@ resource "google_project_service" "container" {
 resource "google_container_cluster" "tsb" {
   name               = var.cluster_name
   project            = var.project_id
-  location           = var.region
+  location           = data.google_compute_zones.available.names[0]
   min_master_version = var.k8s_version
   network            = var.vpc_id
   subnetwork         = var.vpc_subnet

--- a/modules/gcp/k8s/main.tf
+++ b/modules/gcp/k8s/main.tf
@@ -87,7 +87,7 @@ resource "local_file" "kubeconfig" {
 }
 
 resource "local_file" "gen_kubeconfig_sh" {
-  content         = "gcloud container clusters get-credentials --project ${var.project_id} --region ${var.region} ${var.cluster_name}"
+  content         = "gcloud container clusters get-credentials --project ${var.project_id} --region ${data.google_compute_zones.available.names[0]} ${var.cluster_name}"
   filename        = "${var.output_path}/generate-${var.cluster_name}-kubeconfig.sh"
   file_permission = "0755"
 }

--- a/modules/gcp/k8s_auth/main.tf
+++ b/modules/gcp/k8s_auth/main.tf
@@ -1,9 +1,14 @@
+data "google_compute_zones" "available" {
+  project = var.project_id
+  region  = var.region
+}
+
 module "gke_auth" {
   source = "terraform-google-modules/kubernetes-engine/google//modules/auth"
 
   project_id           = var.project_id
   cluster_name         = var.cluster_name
-  location             = var.region
+  location             = data.google_compute_zones.available.names[0]
   use_private_endpoint = false
 
 }


### PR DESCRIPTION
1. downsized kubernetes nodes to all clusters to 2vCPU/8GB
2. downsized jumpboxes to the smallest generally available instances 1vCPU/1-2GB
3. GKE and AKS clusters deployed in the single AZ, to avoid cross-AZ charges
4. EKS is deployed across minimum number of AZs - 2 AZs, enforced by AWS to minimize cross-AZ charges.