### PR TITLE
temporary fix to cont using module eks ver 19.0

### DIFF
--- a/modules/aws/k8s/main.tf
+++ b/modules/aws/k8s/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.70"  # Latest 5.x version
+    }
+  }
+}
+
 data "aws_availability_zones" "available" {}
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"


### PR DESCRIPTION
this is temporary change to continue using:

```module "eks" {
  source  = "terraform-aws-modules/eks/aws"
  version = "~> 19.0"
  ```
  
 to avoid Unsupported argument errors.
  
 proper fix will be applied:
  
  ```module "eks" {
  source  = "terraform-aws-modules/eks/aws"
  version = "~> 20.24"  # Compatible with AWS provider 6.x
}
```

but it requires more changes in the code:
https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/UPGRADE-20.0.md

  
  